### PR TITLE
Fixes RectTransform only being added when a Graphic Component is added

### DIFF
--- a/CommunityEntity.UI.cs
+++ b/CommunityEntity.UI.cs
@@ -61,7 +61,7 @@ public partial class CommunityEntity
                 return;
             }
 
-            var go = new GameObject( json.GetString( "name", "AddUI CreatedPanel" ) );
+            var go = new GameObject( json.GetString( "name", "AddUI CreatedPanel" ) , typeof(RectTransform) );
             go.transform.SetParent( parentPanel.transform, false );
             RegisterUi( go );
 


### PR DESCRIPTION
When a new UI object is created it starts off in the default scene and is lacking a RectTransform.

It only gets a RectTransform when a graphic component (Image,RawImage,Button) is added to it.

This intoduces bugs if send the RectTransform component firs and makes it impossible to create a GUI element without any graphical components (can't have multiple elements grouped under a single transform)