### PR TITLE
Add ability to move client UIs from the server side

### DIFF
--- a/CommunityEntity.UI.cs
+++ b/CommunityEntity.UI.cs
@@ -124,11 +124,6 @@ public partial class CommunityEntity
         rt.offsetMax = offsetMax;
     }
     
-    private float Flip(float f)
-    {
-        return 1 - f;
-    }
-    
     private float EaseIn(float f)
     {
         return f * f;
@@ -136,7 +131,7 @@ public partial class CommunityEntity
     
     private float EaseOut(float f)
     {
-        return Flip(EaseIn(Flip(f)));
+        return 1 - EaseIn(1 - f);
     }
     
     private float EaseInOut(float f)


### PR DESCRIPTION
Hello, I see this repository is getting attention again, which is fantastic. I'd like to offer a contribution, as I operate a server that depends heavily on complicated server-sided UI like the following:

<img src="https://user-images.githubusercontent.com/67132971/165011651-dcd8e97e-7567-47b4-af1f-6f561ec6359c.png" data-canonical-src="https://user-images.githubusercontent.com/67132971/165011651-dcd8e97e-7567-47b4-af1f-6f561ec6359c.png" width="500" />

The primary thing I'd like to see is the ability to move UI elements across the screen, optionally animating them in the process. This would allow for much more responsive and fluid interfaces, and less garbage on the client and server (as I'd have to send less duplicate UIs).

Unity can do this pretty easily just by changing the RectTransform anchors, so I've added an RPC to start a coroutine to move the UI to a target position on the client. Also added ease-in, ease-out, and ease-in-out easings with a duration to make it smoother.

Currently takes the following JSON packet, a list of MoveUI requests that it will parse all at once:

```
[	
    {
	"name": "TestPanel7766",
	"anchormin": "0.5 0",
	"anchormax": "1 1",
	"duration": "0.25",
	"easing": "in-out"
    }
]
```

Due to the nature of this repo, I had to test in an empty Unity project. AFAIK it should work fine, panels with children animate correctly, but I'm unable to test some components.