### PR TITLE
Added ability to destroy ui within AddUI rpc

### DIFF
--- a/CommunityEntity.UI.cs
+++ b/CommunityEntity.UI.cs
@@ -55,7 +55,10 @@ public partial class CommunityEntity
         foreach ( var value in jsonArray )
         {
             var json = value.Obj;
-
+            if ( json.ContainsKey( "destroyUi" ) )
+            {
+                DestroyPanel( json.GetString( "destroyUi", "AddUI CreatedPanel" ) );
+            }
             var parentPanel = FindPanel( json.GetString( "parent", "Overlay" ) );
             if ( parentPanel == null )
             {


### PR DESCRIPTION
**Quick Summary**
This pull request adds the ability to destroy ui within the same rpc (and thus within the same network package) as adding ui.

**Example Usage**
Sending the json:
```json
[
  {
    "destroyUi": "TestPanel7766",                                            
    "name": "TestPanel7766",
    "parent": "Overlay",
    "components": [
      {
        "type":"UnityEngine.UI.RawImage",
        "imagetype": "Tiled",
        "color": "1.0 1.0 1.0 1.0",
        "url": "http://files.facepunch.com/garry/2015/June/03/2015-06-03_12-19-17.jpg",
      },
      {
        "type":"RectTransform",
        "anchormin": "0 0",
        "anchormax": "1 1"
      },
      {
        "type":"NeedsCursor"
      }
    ]
  }
]
```
Using the AddUI rpc would both destroy the ui element "TestPanel7766" and add a new ui element named "TestPanel7766" using the "destroyUi" option that this pull request adds.

**Why?**
Right now the usual way to do this is to send a DestroyUI rpc then an AddUI rpc right after each other.
But the issue is, under my observations, when players have moderate ping (I have personally tested with 100), using this method without this pull request causes flicker, I believe this is because sometimes the two network packets for the two rpc's does not arrive within the same client frame thus the ui is added 1 or more frames after it was destroyed client side. This problem gets worse depending on how complicated the ui is (because complicated ui take longer to send - potentially even making it happen no matter what your ping is - bad player internet connection will also further worsen this)

The simple additions of the 4 lines in this pull request fixes this, since the destroy and add will be guaranteed to happen within the same frame.

**Known Alternative**
You could fix this using 2 identical uis but with different names and sending AddUI name1, DestroyUI name2, AddUI name2, DestroyUI name1, etc rpc in that order. But that is pretty complicated in some cases, and doesn't work for everything, and this pull request would be a lot simpler. You also wouldn't be able to make your ui transparent, atleast not the parts where this method is used since you would sometimes see the 2 uis on top of eachother instead of flashing.

**Other Alternative Methods?**
If anyone know of alternative ways in which to fix the issues mentioned above without this pull request do let me know. Or if you think this pull request could be changed in anyway