### PR TITLE
Add extendable Animation Component

### DIFF
--- a/Community.UI.Animation.cs
+++ b/Community.UI.Animation.cs
@@ -1,0 +1,115 @@
+using UnityEngine;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Facepunch.Extend;
+using System.IO;
+
+#if CLIENT
+
+public partial class CommunityEntity
+{
+	private class Animation : MonoBehaviour
+	{
+		public List<AnimationProperty> properties = new List<AnimationProperty>();
+		
+		public void Start()
+		{
+			foreach(var prop in properties)
+			{
+				prop.routine = StartCoroutine(prop.Animate());
+			}
+		}
+		
+		public void Kill()
+		{
+			foreach(var prop in properties)
+			{
+				StopCoroutine(prop.routine);
+			}
+			properties.Clear();
+		}
+	}
+	
+	private class AnimationProperty
+	{
+		public float duration = 0f;
+		public float delay = 0f;
+		public bool repeat = false;
+		public bool repeatDelay = 0f;
+		public string type;
+		public string from;
+		public string to;
+		
+		public Coroutine routine;
+		
+		public IEnumerator Animate()
+		{
+			if(delay > 0f) yield return new WaitForSeconds(delay);
+			
+			if(repeatDelay <= 0f) repeatDelay = duration;
+      
+			do
+			{
+				AnimateProperty();
+				if(repeatDelay > 0f) yield return new WaitForSeconds(repeatDelay);
+			}
+			while(repeat);
+		}
+		
+		public void AnimateProperty()
+		{
+			switch(type){
+				case "Opacity":
+					{
+						float fromOpacity;
+						float toOpacity;
+						
+						// we need a valid toOpacity
+						if(!float.TryParse(to, out toOpacity)) break;
+						// unlike the toOpacity, a from value is optional. if we omit a from value the crossfade will instead use the current alpha
+						float.TryParse(from, out fromOpacity);
+						
+						foreach(var c in gameObject.GetComponents<UnityEngine.UI.Graphic>()){
+							if(fromOpacity != null) c.canvasRenderer.SetAlpha(fromOpacity);
+							c.CrossFadeAlpha(toOpacity, duration, true);
+						}
+						
+						break;
+					}
+				case "Color":
+					{
+						Color fromColor = ColorEx.Parse(from);
+						Color toColor = ColorEx.Parse(to);
+						
+						//dont use the from color if the from value was ommited
+						bool useFrom = string.IsNullOrEmpty(from);
+						
+						foreach(var c in gameObject.GetComponents<UnityEngine.UI.Graphic>()){
+							if(useFrom) c.canvasRenderer.SetColor(fromColor);
+							c.CrossFadeColor(toColor, duration, true, false);
+						}
+						
+						break;
+					}
+				case "ColorWithAlpha":
+					{
+						Color fromColor = ColorEx.Parse(from);
+						Color toColor = ColorEx.Parse(to);
+						
+						//dont use the from color if the from value was ommited
+						bool useFrom = string.IsNullOrEmpty(from);
+						
+						foreach(var c in gameObject.GetComponents<UnityEngine.UI.Graphic>()){
+							if(useFrom) c.canvasRenderer.SetColor(fromColor);
+							c.CrossFadeColor(toColor, duration, true, true);
+						}
+						
+						break;
+					}
+			}
+		}
+	}
+}
+
+#endif

--- a/Community.UI.Animation.cs
+++ b/Community.UI.Animation.cs
@@ -53,6 +53,7 @@ public partial class CommunityEntity
 			{
 				AnimateProperty();
 				if(repeatDelay > 0f) yield return new WaitForSeconds(repeatDelay);
+				else  yield return null;
 			}
 			while(repeat);
 		}

--- a/CommunityEntity.UI.cs
+++ b/CommunityEntity.UI.cs
@@ -321,6 +321,30 @@ public partial class CommunityEntity
                     go.AddComponent<NeedsKeyboard>();
                     break;
                 }
+			case "Animation":
+				{
+					List<AnimationProperty> props = new List<AnimationProperty>();
+					foreach(var prop in Obj.GetArray("properties"))
+					{
+						props.Add(new AnimationProperty{
+							duration = prop.GetFloat("duration", 0f),
+							delay = prop.GetFloat("delay", 0f),
+							repeat = prop.GetBoolean("repeat", false),
+							repeatDelay = prop.GetFloat("repeatDelay", 0f),
+							type = prop.GetString("type", null),
+							from = prop.GetString("from", null),
+							to = prop.GetString("to", null)
+						});
+					}
+					// dont bother creating the animation component if it has no properties
+					if(props.Count == 0) break;
+					
+					var a = go.AddComponent<Animation>();
+					a.properties = props;
+					
+					a.Start();
+					break;
+				}
         }
     }
     
@@ -386,6 +410,12 @@ public partial class CommunityEntity
         if ( !panel )
             return;
 
+
+        var animation = panel.GetComponent<Animation>();
+		if(animation){
+			animation.Kill();
+		}
+		
         var fadeOut = panel.GetComponent<FadeOut>();
         if ( fadeOut )
         {


### PR DESCRIPTION
# Adding an Extendable Animation Component
**Summary**
this Fork adds an Animation Component that allows you to animate various properties of a UI Panel, additional properties can be easily added through future commits _(currently only supports opacity & color)_
Animations are applied upon creation of the UI, and support delays aswell as repetition

## Why?
**Removing the static feeling from UIs**
Custom UIs are a vital tool for plugin devs, they help with conveying information & provide a better way of interaction than chat and console can provide, but UI heavy plugins can often feel very static, meaning that once the UI is there the screen appears frozen until the user sends another action to the server

**Creating Viability**
its not impossible to create animated UIs with the current feature set, as the fadeIn and fadeOut do give 1 degree of animation, but this comes at the cost of server strain, very limited possibilites & a difficult developer experience

**Setting the foundation**
the Component was designed without a specific Purpose (unlike fadeIn and fadeOut), instead focusing on creating a solid base for simple "from - to" animations. a focus was put on including common features like delays & repeatability ensure that animations could be created alongside the UI instead being forced to continuously send animations over from the server.

## The Breakdown
this fork has 2 things at its core, the ` Animation Component` and the `AnimationProperty`.  the animation component is attached to the panel to handle things like starting animations & destroying them when the panel gets destroyed. while the AnimationProperty holds the data required to perform an animation aswell as the coroutine that executes it and keeps track of delay and repetition

to use the animation system, a developer can add the component by using the following Json Representation 
```json
{
  "type":"Animation",
  "properties": [
    {
      "duration" : 1.0,
      "delay" : 1.0,
      "repeat" : true,
      "repeatDelay" : 2.5,
      "type" : "Opacity",
      "from" : "0.0",
      "to" : "1.0",
    }
  ]
},
```
an important thing to point out is that these components are not _Meta_ Components, meaning that they cant be applied to a single component but to the entire panel (an animation cant just affect the text, it affects any component including inputs, images & buttons **at once**).

the seperation of animation components & properties enable you to create multiple animations on the same panel instead of having to create a new component for each animation. while a simple from-to animation can be great, the true power of this feature lies in the usage of delay & repeatDelay to make multiple AnimationProperties work together as one.

## Usecase & Comparison
to entice Facepunch into integrating this & get other devs to use it, i've made an example of where this addition has a big impact on the perceived polish of a UI.

(still have to make it first)
