### PR TITLE
Prevents Mipmap from destroying image quality

### DIFF
--- a/CommunityEntity.UI.cs
+++ b/CommunityEntity.UI.cs
@@ -357,8 +357,9 @@ public partial class CommunityEntity
         }
 
 
-        var texture = www.texture;
-        if ( texture == null || c == null )
+        Texture2D texture = new Texture2D(2, 2, TextureFormat.RGBA32, false);
+        www.LoadImageIntoTexture(texture);
+        if ( c == null )
         {
             Debug.Log( "Error downloading image: " + p + " (not an image)" );
             www.Dispose();


### PR DESCRIPTION
**TLDR:** loads images from the web with the same quality as it does when loading from the server

this commit changes 3 lines of code to fix the default way images from the web get loaded into a texture, causing abhorrent image quality on lower graphics quality