### PR TITLE
Applies FadeOut to Child Components

### DIFF
--- a/CommunityEntity.UI.FadeOut.cs
+++ b/CommunityEntity.UI.FadeOut.cs
@@ -17,7 +17,7 @@ public partial class CommunityEntity
         public void FadeOutAndDestroy()
         {
             Invoke( "Kill", duration + .1f );
-            foreach ( var c in gameObject.GetComponents<UnityEngine.UI.Graphic>() )
+            foreach ( var c in gameObject.GetComponentsInChildren<UnityEngine.UI.Graphic>() )
             {
                 c.CrossFadeAlpha( 0f, duration, false );
             }


### PR DESCRIPTION
Applying the FadeOut to all child components creates a better visual feel, preventing the buggy behaviour that currently exists where the parent fades out but children stay opaque until they get destroyed