### PR TITLE
InputField's Placeholder

### DIFF
--- a/CommunityEntity.UI.cs
+++ b/CommunityEntity.UI.cs
@@ -374,6 +374,13 @@ public partial class CommunityEntity
                         c.inputType = password ? InputField.InputType.Password : InputField.InputType.Standard;
                     }
 
+                    if (allowUpdate && obj.ContainsKey("placeHolder"))
+                    {
+                        var placeholder = c.placeholder.GetComponent<Text>();
+                        if(placeholder != null)
+                            placeholder.text = obj.GetString("placeHolder");
+                    }
+
                     if ( obj.TryGetBoolean( "needsKeyboard", out var needsKeyboard ) )
                     {
                         var comp = GetOrAddComponent<NeedsKeyboardInputField>();


### PR DESCRIPTION
# Place holders

Allow the use of place holders in input fields via json field `placeHolder`.
That way, players don't have to erase the default text anymore and the servers can give tooltips on what to use the input field for.