### PR TITLE
Parameter to change the object's activity, activeSelf.

### DIFF
--- a/CommunityEntity.UI.cs
+++ b/CommunityEntity.UI.cs
@@ -102,6 +102,9 @@ public partial class CommunityEntity
                 if ( rt )
                     FitParent(rt);
             }
+		
+	    if (json.ContainsKey("activeSelf"))
+                go.SetActive(json.GetBoolean("activeSelf", true));
 
             foreach ( var component in json.GetArray( "components" ) )
             {


### PR DESCRIPTION
Instead of destroying and recreating it, it is much better to send all the necessary UI beforehand and then switch it with short requests afterwards.

The current approach has several disadvantages:
- When an object is recreated, it is moved to the end of the parent object, which can mess up the user interface.
- Inefficient usage. Chances are, most of the UI being sent hasn't changed, and we have to send the full object along with its children because the object was previously destroyed.

These drawbacks have workarounds, but instead of using crutches, we can use 2 lines of code that will improve things dramatically.

This will also encourage the use of component updates to their full potential.