### PR TITLE
Fix Input FIeld Newlines

### DIFF
--- a/CommunityEntity.UI.cs
+++ b/CommunityEntity.UI.cs
@@ -393,12 +393,12 @@ public partial class CommunityEntity
                         c.onEndEdit.AddListener( ( value ) => { ConsoleNetwork.ClientRunOnServer( cmd + " " + value ); } );
                     }
 
+                    if ( ShouldUpdateField( "lineType" ) )
+                        c.lineType = ParseEnum( obj.GetString( "lineType", "SingleLine" ), InputField.LineType.SingleLine );
                     if ( ShouldUpdateField( "text" ) )
                         c.text = obj.GetString( "text", "Text" );
                     if ( ShouldUpdateField( "readOnly" ) )
                         c.readOnly = obj.GetBoolean( "readOnly", false );
-                    if ( ShouldUpdateField( "lineType" ) )
-                        c.lineType = ParseEnum( obj.GetString( "lineType", "SingleLine" ), InputField.LineType.SingleLine );
 
                     if ( obj.TryGetBoolean( "password", out var password ) )
                     {


### PR DESCRIPTION
turns out SingleLine removes any \n newlines from the string the moment the text is applied, so even if the lineType is set to a Multiline variant afterwards the string will still be stripped (See InputField.SetText)

this PR fixes this by moving a line of code around