### PR TITLE
activeSelf property

### DIFF
--- a/CommunityEntity.UI.cs
+++ b/CommunityEntity.UI.cs
@@ -102,6 +102,9 @@ public partial class CommunityEntity
                 if ( rt )
                     FitParent(rt);
             }
+		
+	    if (json.ContainsKey("activeSelf"))
+                go.SetActive(json.GetBoolean("activeSelf", true));
 
             foreach ( var component in json.GetArray( "components" ) )
             {


### PR DESCRIPTION
Adds switching of object's activity. Instead of destroying and recreating it, it is much better to send all the necessary UI beforehand and then switch it with short requests afterwards.