### PR TITLE
LayoutGroup/ContentSizeFitter/LayoutElement JSON support (+tests & videos)

### DIFF
--- a/CommunityEntity.UI.cs
+++ b/CommunityEntity.UI.cs
@@ -498,6 +498,116 @@ public partial class CommunityEntity
 
                     break;
                 }
+            case "UnityEngine.UI.HorizontalLayoutGroup":
+                {
+                    var c = GetOrAddComponent<HorizontalLayoutGroup>();
+                    HandleEnableState(obj, c);
+
+                    if (ShouldUpdateField("spacing"))
+                        c.spacing = obj.GetFloat("spacing", 0f);
+                    if (ShouldUpdateField("childAlignment"))
+                        c.childAlignment = ParseEnum(obj.GetString("childAlignment", "UpperLeft"), TextAnchor.UpperLeft);
+                    if (ShouldUpdateField("childForceExpandWidth"))
+                        c.childForceExpandWidth = obj.GetBoolean("childForceExpandWidth", true);
+                    if (ShouldUpdateField("childForceExpandHeight"))
+                        c.childForceExpandHeight = obj.GetBoolean("childForceExpandHeight", true);
+                    if (ShouldUpdateField("childControlWidth"))
+                        c.childControlWidth = obj.GetBoolean("childControlWidth", false);
+                    if (ShouldUpdateField("childControlHeight"))
+                        c.childControlHeight = obj.GetBoolean("childControlHeight", false);
+                    if (ShouldUpdateField("childScaleWidth"))        
+                        c.childScaleWidth  = obj.GetBoolean("childScaleWidth",  false);
+                    if (ShouldUpdateField("childScaleHeight"))        
+                        c.childScaleHeight = obj.GetBoolean("childScaleHeight", false);
+
+                    ApplyPadding(c, obj, ShouldUpdateField);
+
+                    break;
+                }
+            case "UnityEngine.UI.VerticalLayoutGroup":
+                {
+                    var c = GetOrAddComponent<VerticalLayoutGroup>();
+                    HandleEnableState(obj, c);
+
+                    if (ShouldUpdateField("spacing"))                 
+                        c.spacing = obj.GetFloat("spacing", 0f);
+                    if (ShouldUpdateField("childAlignment"))          
+                        c.childAlignment = ParseEnum(obj.GetString("childAlignment", "UpperLeft"), TextAnchor.UpperLeft);
+                    if (ShouldUpdateField("childForceExpandWidth"))   
+                        c.childForceExpandWidth  = obj.GetBoolean("childForceExpandWidth",  true);
+                    if (ShouldUpdateField("childForceExpandHeight")) 
+                        c.childForceExpandHeight = obj.GetBoolean("childForceExpandHeight", true);
+                    if (ShouldUpdateField("childControlWidth"))      
+                        c.childControlWidth  = obj.GetBoolean("childControlWidth",  false);
+                    if (ShouldUpdateField("childControlHeight"))   
+                        c.childControlHeight = obj.GetBoolean("childControlHeight", false);
+                    if (ShouldUpdateField("childScaleWidth"))     
+                        c.childScaleWidth  = obj.GetBoolean("childScaleWidth",  false);
+                    if (ShouldUpdateField("childScaleHeight"))   
+                        c.childScaleHeight = obj.GetBoolean("childScaleHeight", false);
+
+                    ApplyPadding(c, obj, ShouldUpdateField);
+                    
+                    break;
+                }
+            case "UnityEngine.UI.GridLayoutGroup":
+                {
+                    var c = GetOrAddComponent<GridLayoutGroup>();
+                    HandleEnableState(obj, c);
+
+                    if (ShouldUpdateField("cellSize"))
+                        c.cellSize = Vector2Ex.Parse(obj.GetString("cellSize", "100 100"));
+                    if (ShouldUpdateField("spacing"))
+                        c.spacing = Vector2Ex.Parse(obj.GetString("spacing", "0 0"));
+                    if (ShouldUpdateField("startCorner"))
+                        c.startCorner = ParseEnum(obj.GetString("startCorner", "UpperLeft"), GridLayoutGroup.Corner.UpperLeft);
+                    if (ShouldUpdateField("startAxis"))
+                        c.startAxis = ParseEnum(obj.GetString("startAxis", "Horizontal"), GridLayoutGroup.Axis.Horizontal);
+                    if (ShouldUpdateField("childAlignment"))
+                        c.childAlignment = ParseEnum(obj.GetString("childAlignment", "UpperLeft"), TextAnchor.UpperLeft);
+                    if (ShouldUpdateField("constraint"))
+                        c.constraint = ParseEnum(obj.GetString("constraint", "Flexible"), GridLayoutGroup.Constraint.Flexible);
+                    if (ShouldUpdateField("constraintCount"))
+                        c.constraintCount = obj.GetInt("constraintCount", c.constraintCount);
+
+                    ApplyPadding(c, obj, ShouldUpdateField);
+                    
+                    break;
+                }
+            case "UnityEngine.UI.ContentSizeFitter":
+                {
+                    var c = GetOrAddComponent<ContentSizeFitter>();
+                    HandleEnableState(obj, c);
+
+                    if (ShouldUpdateField("horizontalFit"))
+                        c.horizontalFit = ParseEnum(obj.GetString("horizontalFit", "Unconstrained"), ContentSizeFitter.FitMode.Unconstrained);
+                    if (ShouldUpdateField("verticalFit"))
+                        c.verticalFit = ParseEnum(obj.GetString("verticalFit", "Unconstrained"), ContentSizeFitter.FitMode.Unconstrained);
+
+                    break;
+                }
+            case "UnityEngine.UI.LayoutElement":
+                {
+                    var c = GetOrAddComponent<LayoutElement>();
+                    HandleEnableState(obj, c);
+
+                    if (ShouldUpdateField("preferredWidth"))  
+                        c.preferredWidth = obj.GetFloat("preferredWidth", -1f);
+                    if (ShouldUpdateField("preferredHeight")) 
+                        c.preferredHeight = obj.GetFloat("preferredHeight", -1f);
+                    if (ShouldUpdateField("minWidth"))      
+                        c.minWidth = obj.GetFloat("minWidth", 0f);
+                    if (ShouldUpdateField("minHeight"))      
+                        c.minHeight = obj.GetFloat("minHeight", 0f);
+                    if (ShouldUpdateField("flexibleWidth"))  
+                        c.flexibleWidth = obj.GetFloat("flexibleWidth", 0f);
+                    if (ShouldUpdateField("flexibleHeight")) 
+                        c.flexibleHeight = obj.GetFloat("flexibleHeight", 0f);
+                    if (ShouldUpdateField("ignoreLayout"))
+                        c.ignoreLayout = obj.GetBoolean("ignoreLayout", false);
+
+                    break;
+                }
             case "Draggable":
                 {
                     var drag = go.GetComponent<Draggable>();
@@ -729,6 +839,38 @@ public partial class CommunityEntity
         transform.anchorMax = Vector2.one;
         transform.offsetMin = Vector2.zero;
         transform.offsetMax = Vector2.one; // to preserve the shoddy offsetmax default that alot of existing UIs rely on
+    }
+    
+    private void ApplyPadding(LayoutGroup g, JSON.Object obj, Func<string, bool> ShouldUpdateField)
+    {
+        if (g == null || obj == null) return;
+
+        // 1) Shorthand "padding" field: "l t r b" (or a single "x" to apply to all sides)
+        if (ShouldUpdateField("padding") && obj.ContainsKey("padding"))
+        {
+            var raw = obj.GetString("padding", "0 0 0 0");
+            var parts = raw.Split(new[] { ' ', ',', ';', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+
+            int l = g.padding.left, t = g.padding.top, r = g.padding.right, b = g.padding.bottom;
+
+            if (parts.Length == 1)
+            {
+                if (int.TryParse(parts[0], out var v))
+                    l = t = r = b = v;
+            }
+            else if (parts.Length >= 4)
+            {
+                int.TryParse(parts[0], out l);
+                int.TryParse(parts[1], out t);
+                int.TryParse(parts[2], out r);
+                int.TryParse(parts[3], out b);
+            }
+
+            g.padding.left   = l;
+            g.padding.top    = t;
+            g.padding.right  = r;
+            g.padding.bottom = b;
+        }
     }
 
     private static T ParseEnum<T>(string value, T defaultValue)

--- a/Tests/test-grid-min.json
+++ b/Tests/test-grid-min.json
@@ -1,0 +1,50 @@
+[
+  {
+    "name":"G_Panel","parent":"Overlay",
+    "components":[
+      { "type":"UnityEngine.UI.Image","color":"0 0 0 0.18" },
+      { "type":"RectTransform","anchormin":"0.2 0.25","anchormax":"0.8 0.75","offsetmin":"0 0","offsetmax":"0 0" },
+      { "type":"UnityEngine.UI.GridLayoutGroup",
+        "cellSize":"160 64",
+        "spacing":"16 16",
+        "startCorner":"UpperLeft",
+        "startAxis":"Horizontal",
+        "childAlignment":"MiddleCenter",
+        "constraint":"Flexible",
+        "padding":"12 12 12 12"
+      }
+    ]
+  },
+
+  { "name":"G_Item_1","parent":"G_Panel","components":[
+      { "type":"UnityEngine.UI.Image","color":"0.9 0.3 0.3 0.95" }
+  ]},
+  { "name":"G_Item_1_Label","parent":"G_Item_1","components":[
+      { "type":"RectTransform","anchormin":"0 0","anchormax":"1 1","offsetmin":"8 6","offsetmax":"-8 -6" },
+      { "type":"UnityEngine.UI.Text","text":"Item 1","fontSize":16,"font":"RobotoCondensed-Bold.ttf","align":"MiddleCenter","color":"1 1 1 1" }
+  ]},
+
+  { "name":"G_Item_2","parent":"G_Panel","components":[
+      { "type":"UnityEngine.UI.Image","color":"0.3 0.9 0.3 0.95" }
+  ]},
+  { "name":"G_Item_2_Label","parent":"G_Item_2","components":[
+      { "type":"RectTransform","anchormin":"0 0","anchormax":"1 1","offsetmin":"8 6","offsetmax":"-8 -6" },
+      { "type":"UnityEngine.UI.Text","text":"Item 2","fontSize":16,"font":"RobotoCondensed-Bold.ttf","align":"MiddleCenter","color":"1 1 1 1" }
+  ]},
+
+  { "name":"G_Item_3","parent":"G_Panel","components":[
+      { "type":"UnityEngine.UI.Image","color":"0.3 0.3 0.9 0.95" }
+  ]},
+  { "name":"G_Item_3_Label","parent":"G_Item_3","components":[
+      { "type":"RectTransform","anchormin":"0 0","anchormax":"1 1","offsetmin":"8 6","offsetmax":"-8 -6" },
+      { "type":"UnityEngine.UI.Text","text":"Item 3","fontSize":16,"font":"RobotoCondensed-Bold.ttf","align":"MiddleCenter","color":"1 1 1 1" }
+  ]},
+
+  { "name":"G_Item_4","parent":"G_Panel","components":[
+      { "type":"UnityEngine.UI.Image","color":"0.9 0.9 0.3 0.95" }
+  ]},
+  { "name":"G_Item_4_Label","parent":"G_Item_4","components":[
+      { "type":"RectTransform","anchormin":"0 0","anchormax":"1 1","offsetmin":"8 6","offsetmax":"-8 -6" },
+      { "type":"UnityEngine.UI.Text","text":"Item 4","fontSize":16,"font":"RobotoCondensed-Bold.ttf","align":"MiddleCenter","color":"1 1 1 1" }
+  ]}
+]

--- a/Tests/test-horizontal-min.json
+++ b/Tests/test-horizontal-min.json
@@ -1,0 +1,43 @@
+[
+  {
+    "name":"H_Panel","parent":"Overlay",
+    "components":[
+      { "type":"UnityEngine.UI.Image","color":"0 0 0 0.18" },
+      { "type":"RectTransform","anchormin":"0.15 0.72","anchormax":"0.85 0.86","offsetmin":"0 0","offsetmax":"0 0" },
+      { "type":"UnityEngine.UI.HorizontalLayoutGroup",
+        "spacing":20,
+        "childAlignment":"MiddleCenter",
+        "childForceExpandWidth":false,"childForceExpandHeight":false,
+        "childControlWidth":true,"childControlHeight":true,
+        "padding":"12 12 12 12"
+      }
+    ]
+  },
+
+  { "name":"H_Item_A","parent":"H_Panel","components":[
+      { "type":"UnityEngine.UI.LayoutElement","preferredWidth":200,"preferredHeight":120 },
+      { "type":"UnityEngine.UI.Image","sprite":"assets/content/ui/ui.rounded.tga","imagetype":"Sliced","color":"0.2 0.6 1 0.9" }
+  ]},
+  { "name":"H_Item_A_Label","parent":"H_Item_A","components":[
+      { "type":"RectTransform","anchormin":"0 0","anchormax":"1 1","offsetmin":"8 8","offsetmax":"-8 -8" },
+      { "type":"UnityEngine.UI.Text","text":"COMBAT","fontSize":18,"font":"RobotoCondensed-Bold.ttf","align":"MiddleCenter","color":"1 1 1 1" }
+  ]},
+
+  { "name":"H_Item_B","parent":"H_Panel","components":[
+      { "type":"UnityEngine.UI.LayoutElement","preferredWidth":220,"preferredHeight":120 },
+      { "type":"UnityEngine.UI.Image","sprite":"assets/content/ui/ui.rounded.tga","imagetype":"Sliced","color":"1 0.5 0.2 0.9" }
+  ]},
+  { "name":"H_Item_B_Label","parent":"H_Item_B","components":[
+      { "type":"RectTransform","anchormin":"0 0","anchormax":"1 1","offsetmin":"8 8","offsetmax":"-8 -8" },
+      { "type":"UnityEngine.UI.Text","text":"RAID","fontSize":18,"font":"RobotoCondensed-Bold.ttf","align":"MiddleCenter","color":"1 1 1 1" }
+  ]},
+
+  { "name":"H_Item_C","parent":"H_Panel","components":[
+      { "type":"UnityEngine.UI.LayoutElement","preferredWidth":204,"preferredHeight":120 },
+      { "type":"UnityEngine.UI.Image","sprite":"assets/content/ui/ui.rounded.tga","imagetype":"Sliced","color":"0.4 1 0.4 0.9" }
+  ]},
+  { "name":"H_Item_C_Label","parent":"H_Item_C","components":[
+      { "type":"RectTransform","anchormin":"0 0","anchormax":"1 1","offsetmin":"8 8","offsetmax":"-8 -8" },
+      { "type":"UnityEngine.UI.Text","text":"THIRD (+4px)","fontSize":18,"font":"RobotoCondensed-Bold.ttf","align":"MiddleCenter","color":"1 1 1 1" }
+  ]}
+]

--- a/Tests/test-vertical-min.json
+++ b/Tests/test-vertical-min.json
@@ -1,0 +1,43 @@
+[
+  {
+    "name":"V_Panel","parent":"Overlay",
+    "components":[
+      { "type":"UnityEngine.UI.Image","color":"0 0 0 0.18" },
+      { "type":"RectTransform","anchormin":"0.4 0.22","anchormax":"0.6 0.72","offsetmin":"0 0","offsetmax":"0 0" },
+      { "type":"UnityEngine.UI.VerticalLayoutGroup",
+        "spacing":14,
+        "childAlignment":"MiddleCenter",
+        "childForceExpandWidth":false,"childForceExpandHeight":false,
+        "childControlWidth":true,"childControlHeight":true,
+        "padding":"12 12 12 12"
+      }
+    ]
+  },
+
+  { "name":"V_Item_1","parent":"V_Panel","components":[
+      { "type":"UnityEngine.UI.LayoutElement","preferredWidth":320,"preferredHeight":52 },
+      { "type":"UnityEngine.UI.Image","color":"0.2 0.6 1 0.9" }
+  ]},
+  { "name":"V_Item_1_Label","parent":"V_Item_1","components":[
+      { "type":"RectTransform","anchormin":"0 0","anchormax":"1 1","offsetmin":"8 6","offsetmax":"-8 -6" },
+      { "type":"UnityEngine.UI.Text","text":"Line 1","fontSize":18,"font":"RobotoCondensed-Bold.ttf","align":"MiddleCenter","color":"1 1 1 1" }
+  ]},
+
+  { "name":"V_Item_2","parent":"V_Panel","components":[
+      { "type":"UnityEngine.UI.LayoutElement","preferredWidth":360,"preferredHeight":52 },
+      { "type":"UnityEngine.UI.Image","color":"1 0.5 0.2 0.9" }
+  ]},
+  { "name":"V_Item_2_Label","parent":"V_Item_2","components":[
+      { "type":"RectTransform","anchormin":"0 0","anchormax":"1 1","offsetmin":"8 6","offsetmax":"-8 -6" },
+      { "type":"UnityEngine.UI.Text","text":"Line 2","fontSize":18,"font":"RobotoCondensed-Bold.ttf","align":"MiddleCenter","color":"1 1 1 1" }
+  ]},
+
+  { "name":"V_Item_3","parent":"V_Panel","components":[
+      { "type":"UnityEngine.UI.LayoutElement","preferredWidth":300,"preferredHeight":52 },
+      { "type":"UnityEngine.UI.Image","color":"0.4 1 0.4 0.9" }
+  ]},
+  { "name":"V_Item_3_Label","parent":"V_Item_3","components":[
+      { "type":"RectTransform","anchormin":"0 0","anchormax":"1 1","offsetmin":"8 6","offsetmax":"-8 -6" },
+      { "type":"UnityEngine.UI.Text","text":"Line 3","fontSize":18,"font":"RobotoCondensed-Bold.ttf","align":"MiddleCenter","color":"1 1 1 1" }
+  ]}
+]


### PR DESCRIPTION
### Summary
This PR adds JSON support in CommunityEntity for the main Unity UI layout components:
- HorizontalLayoutGroup
- VerticalLayoutGroup
- GridLayoutGroup
- ContentSizeFitter
- LayoutElement

This lets plugins build centered rows/columns/grids without manual coordinates.

### Implementation details
- Each component follows existing parsing conventions:
  - HandleEnableState(obj, c)
  - ShouldUpdateField: on create we can apply defaults; on update we only touch keys present in JSON
  - Defaults match Unity’s own defaults
- Padding parsing extracted to ApplyPadding(...) helper:
  - "padding": "l t r b"

### Compatibility
- No changes to existing types/branches; new code paths run only if referenced in JSON.
- No breaking changes; update behavior is patch-style, same as other components.

### Testing
- Unity 2022.3.41f1, Editor
- Scenarios (no ScrollRect):
  1) HorizontalLayoutGroup: add/remove (including middle removal), centering is preserved
  2) VerticalLayoutGroup: auto-centering with mixed widths
  3) GridLayoutGroup: childAlignment/spacing/padding/constraint; items reflow as expected
  4) ContentSizeFitter + LayoutElement interplay (preferred/min/flexible)
- Verified `allowUpdate` semantics and that unspecified fields are not touched on update.
- No warnings/errors in console; legacy JSON UIs behave identically.

<h3 align="center">UI Layout Demos</h3>

<table>
  <tr>
    <td width="33%">
      <p align="center"><b>Horizontal</b></p>
      <video src="https://github.com/user-attachments/assets/b67033a1-092a-46ef-851d-eb642b321b39" controls muted playsinline width="100%"></video>
    </td>
    <td width="33%">
      <p align="center"><b>Vertical</b></p>
      <video src="https://github.com/user-attachments/assets/a7cf543b-0a76-4b3b-bbad-15681d78afa9" controls muted playsinline width="100%"></video>
    </td>
    <td width="33%">
      <p align="center"><b>Grid</b></p>
      <video src="https://github.com/user-attachments/assets/9d2e2786-e943-4f8f-8705-942199039ff8" controls muted playsinline width="100%"></video>
    </td>
  </tr>
</table>









