### PR TITLE
Pivot for RectTransform component

### DIFF
--- a/CommunityEntity.UI.cs
+++ b/CommunityEntity.UI.cs
@@ -470,6 +470,8 @@ public partial class CommunityEntity
                             rt.offsetMin = Vector2Ex.Parse( obj.GetString( "offsetmin", "0.0 0.0" ) );
                         if ( ShouldUpdateField( "offsetmax" ) )
                             rt.offsetMax = Vector2Ex.Parse( obj.GetString( "offsetmax", "1.0 1.0" ) );
+						if ( ShouldUpdateField( "pivot" ) )
+                            rt.pivot = Vector2Ex.Parse( obj.GetString( "pivot", "0.5 0.5" ) ); 
                         if ( ShouldUpdateField( "rotation" ) )
                             rt.rotation = Quaternion.Euler( 0, 0, obj.GetFloat("rotation", 0) );
                             

--- a/CommunityEntity.UI.cs
+++ b/CommunityEntity.UI.cs
@@ -462,6 +462,8 @@ public partial class CommunityEntity
                     var rt = go.GetComponent<RectTransform>();
                     if ( rt )
                     {
+						if ( ShouldUpdateField( "pivot" ) )
+                            rt.pivot = Vector2Ex.Parse( obj.GetString( "pivot", "0.5 0.5" ) ); 
                         if ( ShouldUpdateField( "anchormin" ) )
                             rt.anchorMin = Vector2Ex.Parse( obj.GetString( "anchormin", "0.0 0.0" ) );
                         if ( ShouldUpdateField( "anchormax" ) )
@@ -470,8 +472,6 @@ public partial class CommunityEntity
                             rt.offsetMin = Vector2Ex.Parse( obj.GetString( "offsetmin", "0.0 0.0" ) );
                         if ( ShouldUpdateField( "offsetmax" ) )
                             rt.offsetMax = Vector2Ex.Parse( obj.GetString( "offsetmax", "1.0 1.0" ) );
-						if ( ShouldUpdateField( "pivot" ) )
-                            rt.pivot = Vector2Ex.Parse( obj.GetString( "pivot", "0.5 0.5" ) ); 
                         if ( ShouldUpdateField( "rotation" ) )
                             rt.rotation = Quaternion.Euler( 0, 0, obj.GetFloat("rotation", 0) );
                             
@@ -1041,3 +1041,4 @@ public partial class CommunityEntity
 }
 
 #endif
+


### PR DESCRIPTION
With the introduction of ContentSizeFitter, there is now a need for pivot control, as ContentSizeFitter shifts the position dynamically in a way that is not expected.