### PR TITLE
Draggable.Init NRE Fix

### DIFF
--- a/CommunityEntity.UI.Draggable.cs
+++ b/CommunityEntity.UI.Draggable.cs
@@ -128,7 +128,7 @@ public partial class CommunityEntity
             // setup values
             rt = (transform as RectTransform);
             canvasGroup = GetComponent<CanvasGroup>();
-            canvas = GetComponentInParent<Canvas>().transform;
+            canvas = GetComponentInParent<Canvas>(true).transform;
             realParent = rt.parent;
             index = rt.GetSiblingIndex();
 


### PR DESCRIPTION
Attempts to fix an NRE in Draggable.Init when the parented Canvas is currently disabled I.E. Crafting or Inventory. This seems to have broken during the UI Overhead Optimizations work.

Fixes #81 