### PR TITLE
Allow using full asset path for fonts

### DIFF
--- a/CommunityEntity.UI.cs
+++ b/CommunityEntity.UI.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using UnityEngine.UI;
 using System;
 using System.Collections;
@@ -995,7 +995,12 @@ public partial class CommunityEntity
 
     private Font LoadFont(string fontName)
     {
-        var font = FileSystem.Load<Font>( "Assets/Content/UI/Fonts/" + fontName );
+        if (!fontName.StartsWith("assets/", StringComparison.OrdinalIgnoreCase))
+        {
+            fontName = "Assets/Content/UI/Fonts/" + fontName;
+        }
+        
+        var font = FileSystem.Load<Font>( fontName );
         if (font == null) 
         {
             // Fallback to TMP default font if the loading failed


### PR DESCRIPTION
This allows us to use 3rd party fonts that are not stored in the `Assets/Content/UI/Fonts/` path. IE:

- `assets/plugins/rust.ui/icons/fa.ttf`
- `assets/plugins/rust.ui/icons/materialdesignicons-webfont.ttf`