### PR TITLE
Add an optional pixels per unit multiplier to affect slice scaling

### DIFF
--- a/CommunityEntity.UI.cs
+++ b/CommunityEntity.UI.cs
@@ -259,6 +259,9 @@ public partial class CommunityEntity
                         c.type = ParseEnum( obj.GetString( "imagetype", "Simple" ), UnityEngine.UI.Image.Type.Simple );
                     if( ShouldUpdateField( "fillCenter" ) )
                         c.fillCenter = obj.GetBoolean("fillCenter", c.fillCenter);
+                    if (obj.ContainsKey("ppuMultiplier"))
+                        c.pixelsPerUnitMultiplier = obj.GetFloat("ppuMultiplier", 1f);
+
 
                     if ( obj.ContainsKey( "png" ) && uint.TryParse( obj.GetString( "png" ), out var id ) )
                     {


### PR DESCRIPTION
the default implementation sets pixels per unit at 100 ppu for sprites which affects how big each slice of a sliced image is.

this PR adds the ppuMultiplier to the image to adjust it on a per element basis (avoiding the need to cache sprites with different ppus and maintaining default behavior)