### PR TITLE
Add optional layout priority

### DIFF
--- a/CommunityEntity.UI.cs
+++ b/CommunityEntity.UI.cs
@@ -581,6 +581,8 @@ public partial class CommunityEntity
                         c.childScaleHeight = obj.GetBoolean("childScaleHeight", false);
 
                     ApplyPadding(c, obj, ShouldUpdateField);
+                    if (obj.ContainsKey("layoutPriority"))
+                        c.layoutPriority = obj.GetInt("layoutPriority", 1);
 
                     break;
                 }
@@ -607,7 +609,9 @@ public partial class CommunityEntity
                         c.childScaleHeight = obj.GetBoolean("childScaleHeight", false);
 
                     ApplyPadding(c, obj, ShouldUpdateField);
-                    
+                    if (obj.ContainsKey("layoutPriority"))
+                        c.layoutPriority = obj.GetInt("layoutPriority", 1);
+
                     break;
                 }
             case "UnityEngine.UI.GridLayoutGroup":
@@ -631,7 +635,9 @@ public partial class CommunityEntity
                         c.constraintCount = obj.GetInt("constraintCount", c.constraintCount);
 
                     ApplyPadding(c, obj, ShouldUpdateField);
-                    
+                    if (obj.ContainsKey("layoutPriority"))
+                        c.layoutPriority = obj.GetInt("layoutPriority", 1);
+
                     break;
                 }
             case "UnityEngine.UI.ContentSizeFitter":
@@ -665,6 +671,8 @@ public partial class CommunityEntity
                         c.flexibleHeight = obj.GetFloat("flexibleHeight", 0f);
                     if (ShouldUpdateField("ignoreLayout"))
                         c.ignoreLayout = obj.GetBoolean("ignoreLayout", false);
+                    if (obj.ContainsKey("layoutPriority"))
+                        c.layoutPriority = obj.GetInt("layoutPriority", 1);
 
                     break;
                 }


### PR DESCRIPTION
this PR adds a Layout priority to the LayoutElement and all the LayoutGroups/ContentSIzeFitter.

priority is needed to allow for things like using a ContentSizeFitter on an element that also contains a graphic element, as most graphic elements (like text and UI.Image) implement ILayoutElement themselves. including an optional way to set the priority on our ILayoutElement ensures we can do things like have self sizing buttons.