### PR TITLE
Add RoundedRect UI component

### DIFF
--- a/CommunityEntity.UI.RoundedRect.cs
+++ b/CommunityEntity.UI.RoundedRect.cs
@@ -1,0 +1,210 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+#if CLIENT
+
+[RequireComponent( typeof( RectTransform ) )]
+public class RoundedRectGraphic : MaskableGraphic
+{
+    [SerializeField] private float radius = 16f;
+    [SerializeField] private int segments = 8;
+    [SerializeField] private Sprite sprite;
+    [SerializeField] private bool preserveAspect;
+
+    public float Radius
+    {
+        get => radius;
+        set
+        {
+            radius = Mathf.Max( 0f, value );
+            SetVerticesDirty();
+        }
+    }
+
+    public int Segments
+    {
+        get => segments;
+        set
+        {
+            segments = Mathf.Clamp( value, 1, 32 );
+            SetVerticesDirty();
+        }
+    }
+
+    public Sprite Sprite
+    {
+        get => sprite;
+        set
+        {
+            sprite = value;
+            SetMaterialDirty();
+            SetVerticesDirty();
+        }
+    }
+
+    public bool PreserveAspect
+    {
+        get => preserveAspect;
+        set
+        {
+            preserveAspect = value;
+            SetVerticesDirty();
+        }
+    }
+
+    public override Texture mainTexture
+    {
+        get
+        {
+            if ( sprite == null )
+                return s_WhiteTexture;
+
+            return sprite.texture;
+        }
+    }
+
+    protected override void OnValidate()
+    {
+        base.OnValidate();
+
+        radius = Mathf.Max( 0f, radius );
+        segments = Mathf.Clamp( segments, 1, 32 );
+
+        SetMaterialDirty();
+        SetVerticesDirty();
+    }
+
+    protected override void OnPopulateMesh( VertexHelper vh )
+    {
+        vh.Clear();
+
+        Rect rect = rectTransform.rect;
+
+        float width = rect.width;
+        float height = rect.height;
+
+        if ( width <= 0f || height <= 0f )
+            return;
+
+        Rect drawingRect = preserveAspect && sprite != null
+            ? GetPreservedAspectRect( rect, sprite )
+            : rect;
+
+        float left = drawingRect.xMin;
+        float right = drawingRect.xMax;
+        float bottom = drawingRect.yMin;
+        float top = drawingRect.yMax;
+
+        float r = Mathf.Min( radius, drawingRect.width * 0.5f, drawingRect.height * 0.5f );
+        int seg = Mathf.Max( 1, segments );
+
+        Color32 color32 = color;
+
+        var points = new List<Vector2>();
+
+        AddCorner( points, new Vector2( right - r, top - r ), r, 0f, 90f, seg );
+        AddCorner( points, new Vector2( left + r, top - r ), r, 90f, 180f, seg );
+        AddCorner( points, new Vector2( left + r, bottom + r ), r, 180f, 270f, seg );
+        AddCorner( points, new Vector2( right - r, bottom + r ), r, 270f, 360f, seg );
+
+        Vector4 uv = GetSpriteOuterUV( sprite );
+
+        int centerIndex = 0;
+        vh.AddVert(
+            drawingRect.center,
+            color32,
+            new Vector2(
+                Mathf.Lerp( uv.x, uv.z, 0.5f ),
+                Mathf.Lerp( uv.y, uv.w, 0.5f )
+            )
+        );
+
+        for ( int i = 0; i < points.Count; i++ )
+        {
+            Vector2 point = points[i];
+
+            float normalizedX = Mathf.InverseLerp( drawingRect.xMin, drawingRect.xMax, point.x );
+            float normalizedY = Mathf.InverseLerp( drawingRect.yMin, drawingRect.yMax, point.y );
+
+            Vector2 pointUv = new Vector2(
+                Mathf.Lerp( uv.x, uv.z, normalizedX ),
+                Mathf.Lerp( uv.y, uv.w, normalizedY )
+            );
+
+            vh.AddVert( point, color32, pointUv );
+        }
+
+        for ( int i = 0; i < points.Count; i++ )
+        {
+            int current = i + 1;
+            int next = i == points.Count - 1 ? 1 : current + 1;
+
+            vh.AddTriangle( centerIndex, current, next );
+        }
+    }
+
+    private static Rect GetPreservedAspectRect( Rect rect, Sprite sprite )
+    {
+        float spriteWidth = sprite.rect.width;
+        float spriteHeight = sprite.rect.height;
+
+        if ( spriteWidth <= 0f || spriteHeight <= 0f )
+            return rect;
+
+        float spriteRatio = spriteWidth / spriteHeight;
+        float rectRatio = rect.width / rect.height;
+
+        if ( spriteRatio > rectRatio )
+        {
+            float height = rect.width / spriteRatio;
+            float y = rect.y + ( rect.height - height ) * 0.5f;
+            return new Rect( rect.x, y, rect.width, height );
+        }
+        else
+        {
+            float width = rect.height * spriteRatio;
+            float x = rect.x + ( rect.width - width ) * 0.5f;
+            return new Rect( x, rect.y, width, rect.height );
+        }
+    }
+
+    private static Vector4 GetSpriteOuterUV( Sprite sprite )
+    {
+        if ( sprite == null )
+            return new Vector4( 0f, 0f, 1f, 1f );
+
+        Rect textureRect = sprite.textureRect;
+        Texture texture = sprite.texture;
+
+        return new Vector4(
+            textureRect.xMin / texture.width,
+            textureRect.yMin / texture.height,
+            textureRect.xMax / texture.width,
+            textureRect.yMax / texture.height
+        );
+    }
+
+    private static void AddCorner(
+        List<Vector2> points,
+        Vector2 center,
+        float radius,
+        float startAngle,
+        float endAngle,
+        int segments
+    )
+    {
+        for ( int i = 0; i <= segments; i++ )
+        {
+            float t = i / (float)segments;
+            float angle = Mathf.Lerp( startAngle, endAngle, t ) * Mathf.Deg2Rad;
+
+            points.Add( new Vector2(
+                center.x + Mathf.Cos( angle ) * radius,
+                center.y + Mathf.Sin( angle ) * radius
+            ) );
+        }
+    }
+}
+
+#endif

--- a/CommunityEntity.UI.RoundedRect.cs
+++ b/CommunityEntity.UI.RoundedRect.cs
@@ -7,8 +7,12 @@ using UnityEngine.UI;
 [RequireComponent( typeof( RectTransform ) )]
 public class RoundedRectGraphic : MaskableGraphic
 {
+    private const int MaxSegments = 64;
+    private const float MaxRadius = 64f;
+
     [SerializeField] private float radius = 16f;
     [SerializeField] private int segments = 8;
+    [SerializeField] private float softness = 1.5f;
     [SerializeField] private Sprite sprite;
     [SerializeField] private bool preserveAspect;
 
@@ -17,7 +21,7 @@ public class RoundedRectGraphic : MaskableGraphic
         get => radius;
         set
         {
-            radius = Mathf.Max( 0f, value );
+            radius = Mathf.Clamp( value, 0f, MaxRadius );
             SetVerticesDirty();
         }
     }
@@ -27,7 +31,17 @@ public class RoundedRectGraphic : MaskableGraphic
         get => segments;
         set
         {
-            segments = Mathf.Clamp( value, 1, 32 );
+            segments = Mathf.Clamp( value, 1, MaxSegments );
+            SetVerticesDirty();
+        }
+    }
+
+    public float Softness
+    {
+        get => softness;
+        set
+        {
+            softness = Mathf.Max( 0f, value );
             SetVerticesDirty();
         }
     }
@@ -53,23 +67,15 @@ public class RoundedRectGraphic : MaskableGraphic
         }
     }
 
-    public override Texture mainTexture
-    {
-        get
-        {
-            if ( sprite == null )
-                return s_WhiteTexture;
-
-            return sprite.texture;
-        }
-    }
+    public override Texture mainTexture => sprite == null ? s_WhiteTexture : sprite.texture;
 
     protected override void OnValidate()
     {
         base.OnValidate();
 
-        radius = Mathf.Max( 0f, radius );
-        segments = Mathf.Clamp( segments, 1, 32 );
+        radius = Mathf.Clamp( radius, 0f, MaxRadius );
+        segments = Mathf.Clamp( segments, 1, MaxSegments );
+        softness = Mathf.Max( 0f, softness );
 
         SetMaterialDirty();
         SetVerticesDirty();
@@ -81,58 +87,93 @@ public class RoundedRectGraphic : MaskableGraphic
 
         Rect rect = rectTransform.rect;
 
-        float width = rect.width;
-        float height = rect.height;
-
-        if ( width <= 0f || height <= 0f )
+        if ( rect.width <= 0f || rect.height <= 0f )
             return;
 
         Rect drawingRect = preserveAspect && sprite != null
             ? GetPreservedAspectRect( rect, sprite )
             : rect;
 
-        float left = drawingRect.xMin;
-        float right = drawingRect.xMax;
-        float bottom = drawingRect.yMin;
-        float top = drawingRect.yMax;
-
         float r = Mathf.Min( radius, drawingRect.width * 0.5f, drawingRect.height * 0.5f );
-        int seg = Mathf.Max( 1, segments );
-
-        Color32 color32 = color;
-
-        var points = new List<Vector2>();
-
-        AddCorner( points, new Vector2( right - r, top - r ), r, 0f, 90f, seg );
-        AddCorner( points, new Vector2( left + r, top - r ), r, 90f, 180f, seg );
-        AddCorner( points, new Vector2( left + r, bottom + r ), r, 180f, 270f, seg );
-        AddCorner( points, new Vector2( right - r, bottom + r ), r, 270f, 360f, seg );
+        int seg = Mathf.Clamp( segments, 1, MaxSegments );
+        float soft = Mathf.Min( softness, drawingRect.width * 0.5f, drawingRect.height * 0.5f );
 
         Vector4 uv = GetSpriteOuterUV( sprite );
+
+        var innerPoints = BuildRoundedRectPoints( drawingRect, r, seg );
+        Color32 innerColor = color;
+
+        if ( soft <= 0f )
+        {
+            AddFilledShape( vh, drawingRect.center, innerPoints, innerColor, uv, drawingRect );
+            return;
+        }
+
+        Rect outerRect = new Rect(
+            drawingRect.xMin - soft,
+            drawingRect.yMin - soft,
+            drawingRect.width + soft * 2f,
+            drawingRect.height + soft * 2f
+        );
+
+        float outerRadius = r + soft;
+        var outerPoints = BuildRoundedRectPoints( outerRect, outerRadius, seg );
+
+        Color32 outerColor = innerColor;
+        outerColor.a = 0;
 
         int centerIndex = 0;
         vh.AddVert(
             drawingRect.center,
-            color32,
-            new Vector2(
-                Mathf.Lerp( uv.x, uv.z, 0.5f ),
-                Mathf.Lerp( uv.y, uv.w, 0.5f )
-            )
+            innerColor,
+            GetUv( drawingRect.center, uv, drawingRect )
         );
+
+        int innerStart = 1;
+        for ( int i = 0; i < innerPoints.Count; i++ )
+        {
+            Vector2 point = innerPoints[i];
+            vh.AddVert( point, innerColor, GetUv( point, uv, drawingRect ) );
+        }
+
+        int outerStart = innerStart + innerPoints.Count;
+        for ( int i = 0; i < outerPoints.Count; i++ )
+        {
+            Vector2 point = outerPoints[i];
+            vh.AddVert( point, outerColor, GetUv( point, uv, drawingRect ) );
+        }
+
+        int count = innerPoints.Count;
+
+        for ( int i = 0; i < count; i++ )
+        {
+            int currentInner = innerStart + i;
+            int nextInner = innerStart + ( ( i + 1 ) % count );
+
+            vh.AddTriangle( centerIndex, currentInner, nextInner );
+        }
+
+        for ( int i = 0; i < count; i++ )
+        {
+            int currentInner = innerStart + i;
+            int nextInner = innerStart + ( ( i + 1 ) % count );
+            int currentOuter = outerStart + i;
+            int nextOuter = outerStart + ( ( i + 1 ) % count );
+
+            vh.AddTriangle( currentInner, currentOuter, nextOuter );
+            vh.AddTriangle( currentInner, nextOuter, nextInner );
+        }
+    }
+
+    private static void AddFilledShape( VertexHelper vh, Vector2 center, List<Vector2> points, Color32 color, Vector4 uv, Rect uvRect )
+    {
+        int centerIndex = 0;
+        vh.AddVert( center, color, GetUv( center, uv, uvRect ) );
 
         for ( int i = 0; i < points.Count; i++ )
         {
             Vector2 point = points[i];
-
-            float normalizedX = Mathf.InverseLerp( drawingRect.xMin, drawingRect.xMax, point.x );
-            float normalizedY = Mathf.InverseLerp( drawingRect.yMin, drawingRect.yMax, point.y );
-
-            Vector2 pointUv = new Vector2(
-                Mathf.Lerp( uv.x, uv.z, normalizedX ),
-                Mathf.Lerp( uv.y, uv.w, normalizedY )
-            );
-
-            vh.AddVert( point, color32, pointUv );
+            vh.AddVert( point, color, GetUv( point, uv, uvRect ) );
         }
 
         for ( int i = 0; i < points.Count; i++ )
@@ -142,6 +183,36 @@ public class RoundedRectGraphic : MaskableGraphic
 
             vh.AddTriangle( centerIndex, current, next );
         }
+    }
+
+    private static List<Vector2> BuildRoundedRectPoints( Rect rect, float radius, int segments )
+    {
+        float left = rect.xMin;
+        float right = rect.xMax;
+        float bottom = rect.yMin;
+        float top = rect.yMax;
+
+        float r = Mathf.Min( radius, rect.width * 0.5f, rect.height * 0.5f );
+
+        var points = new List<Vector2>( ( segments + 1 ) * 4 );
+
+        AddCorner( points, new Vector2( right - r, top - r ), r, 0f, 90f, segments, true );
+        AddCorner( points, new Vector2( left + r, top - r ), r, 90f, 180f, segments, false );
+        AddCorner( points, new Vector2( left + r, bottom + r ), r, 180f, 270f, segments, false );
+        AddCorner( points, new Vector2( right - r, bottom + r ), r, 270f, 360f, segments, false );
+
+        return points;
+    }
+
+    private static Vector2 GetUv( Vector2 point, Vector4 uv, Rect rect )
+    {
+        float normalizedX = Mathf.InverseLerp( rect.xMin, rect.xMax, point.x );
+        float normalizedY = Mathf.InverseLerp( rect.yMin, rect.yMax, point.y );
+
+        return new Vector2(
+            Mathf.Lerp( uv.x, uv.z, normalizedX ),
+            Mathf.Lerp( uv.y, uv.w, normalizedY )
+        );
     }
 
     private static Rect GetPreservedAspectRect( Rect rect, Sprite sprite )
@@ -161,12 +232,10 @@ public class RoundedRectGraphic : MaskableGraphic
             float y = rect.y + ( rect.height - height ) * 0.5f;
             return new Rect( rect.x, y, rect.width, height );
         }
-        else
-        {
-            float width = rect.height * spriteRatio;
-            float x = rect.x + ( rect.width - width ) * 0.5f;
-            return new Rect( x, rect.y, width, rect.height );
-        }
+
+        float width = rect.height * spriteRatio;
+        float x = rect.x + ( rect.width - width ) * 0.5f;
+        return new Rect( x, rect.y, width, rect.height );
     }
 
     private static Vector4 GetSpriteOuterUV( Sprite sprite )
@@ -191,10 +260,13 @@ public class RoundedRectGraphic : MaskableGraphic
         float radius,
         float startAngle,
         float endAngle,
-        int segments
+        int segments,
+        bool includeFirstPoint
     )
     {
-        for ( int i = 0; i <= segments; i++ )
+        int start = includeFirstPoint ? 0 : 1;
+
+        for ( int i = start; i <= segments; i++ )
         {
             float t = i / (float)segments;
             float angle = Mathf.Lerp( startAngle, endAngle, t ) * Mathf.Deg2Rad;

--- a/CommunityEntity.UI.cs
+++ b/CommunityEntity.UI.cs
@@ -254,10 +254,13 @@ public partial class CommunityEntity
             			c.color = ColorEx.Parse( obj.GetString( "color", "1.0 1.0 1.0 1.0" ) );
 
         			if ( ShouldUpdateField( "radius" ) )
-            			c.Radius = obj.GetFloat( "radius", 16f );
+           				c.Radius = obj.GetFloat( "radius", 16f );
 
         			if ( ShouldUpdateField( "segments" ) )
-            			c.Segments = obj.GetInt( "segments", 8 );
+           				c.Segments = obj.GetInt( "segments", 8 );
+
+        			if ( ShouldUpdateField( "softness" ) )
+           				c.Softness = obj.GetFloat( "softness", 1.5f );
 
         			if ( ShouldUpdateField( "sprite" ) && obj.ContainsKey( "sprite" ) )
             			c.Sprite = FileSystem.Load<Sprite>( obj.GetString( "sprite" ) );

--- a/CommunityEntity.UI.cs
+++ b/CommunityEntity.UI.cs
@@ -245,6 +245,30 @@ public partial class CommunityEntity
                     break;
                 }
 
+			case "RoundedRect":
+    			{
+        			var c = GetOrAddComponent<RoundedRectGraphic>();
+        			HandleEnableState( obj, c );
+
+        			if ( ShouldUpdateField( "color" ) )
+            			c.color = ColorEx.Parse( obj.GetString( "color", "1.0 1.0 1.0 1.0" ) );
+
+        			if ( ShouldUpdateField( "radius" ) )
+            			c.Radius = obj.GetFloat( "radius", 16f );
+
+        			if ( ShouldUpdateField( "segments" ) )
+            			c.Segments = obj.GetInt( "segments", 8 );
+
+        			if ( ShouldUpdateField( "sprite" ) && obj.ContainsKey( "sprite" ) )
+            			c.Sprite = FileSystem.Load<Sprite>( obj.GetString( "sprite" ) );
+
+        			if ( ShouldUpdateField( "preserveAspect" ) )
+            			c.PreserveAspect = obj.GetBoolean( "preserveAspect", false );
+
+        			GraphicComponentCreated( c, obj );
+        			break;
+    			}
+
             case "UnityEngine.UI.Image":
                 {
                     var c = GetOrAddComponent<UnityEngine.UI.Image>();

--- a/Tests/RoundedRect.json
+++ b/Tests/RoundedRect.json
@@ -27,7 +27,8 @@
         "type": "RoundedRect",
         "color": "0.1 0.1 0.1 0.9",
         "radius": 8,
-        "segments": 8
+        "segments": 8,
+        "softness": 1.5
       },
       {
         "type": "RectTransform",
@@ -46,7 +47,8 @@
         "type": "RoundedRect",
         "color": "0.1 0.25 0.1 0.9",
         "radius": 24,
-        "segments": 12
+        "segments": 12,
+        "softness": 1.5
       },
       {
         "type": "RectTransform",
@@ -65,7 +67,8 @@
         "type": "RoundedRect",
         "color": "0.25 0.1 0.1 0.9",
         "radius": 48,
-        "segments": 16
+        "segments": 16,
+        "softness": 1.5
       },
       {
         "type": "RectTransform",
@@ -86,6 +89,7 @@
         "color": "1.0 1.0 1.0 1.0",
         "radius": 24,
         "segments": 12,
+        "softness": 1.5,
         "preserveAspect": false
       },
       {

--- a/Tests/RoundedRect.json
+++ b/Tests/RoundedRect.json
@@ -1,0 +1,100 @@
+[
+  {
+    "name": "RoundedRectTestTitle",
+    "parent": "Overlay",
+    "components": [
+      {
+        "type": "UnityEngine.UI.Text",
+        "text": "RoundedRect comparison: radius 8 / 24 / 48",
+        "fontSize": 16,
+        "align": "MiddleCenter",
+        "color": "1.0 1.0 1.0 1.0"
+      },
+      {
+        "type": "RectTransform",
+        "anchormin": "0.2 0.65",
+        "anchormax": "0.8 0.70",
+        "offsetmin": "0 0",
+        "offsetmax": "0 0"
+      }
+    ]
+  },
+  {
+    "name": "RoundedRectSmall",
+    "parent": "Overlay",
+    "components": [
+      {
+        "type": "RoundedRect",
+        "color": "0.1 0.1 0.1 0.9",
+        "radius": 8,
+        "segments": 8
+      },
+      {
+        "type": "RectTransform",
+        "anchormin": "0.15 0.45",
+        "anchormax": "0.35 0.57",
+        "offsetmin": "0 0",
+        "offsetmax": "0 0"
+      }
+    ]
+  },
+  {
+    "name": "RoundedRectMedium",
+    "parent": "Overlay",
+    "components": [
+      {
+        "type": "RoundedRect",
+        "color": "0.1 0.25 0.1 0.9",
+        "radius": 24,
+        "segments": 12
+      },
+      {
+        "type": "RectTransform",
+        "anchormin": "0.40 0.45",
+        "anchormax": "0.60 0.57",
+        "offsetmin": "0 0",
+        "offsetmax": "0 0"
+      }
+    ]
+  },
+  {
+    "name": "RoundedRectLarge",
+    "parent": "Overlay",
+    "components": [
+      {
+        "type": "RoundedRect",
+        "color": "0.25 0.1 0.1 0.9",
+        "radius": 48,
+        "segments": 16
+      },
+      {
+        "type": "RectTransform",
+        "anchormin": "0.65 0.45",
+        "anchormax": "0.85 0.57",
+        "offsetmin": "0 0",
+        "offsetmax": "0 0"
+      }
+    ]
+  },
+  {
+    "name": "RoundedRectSprite",
+    "parent": "Overlay",
+    "components": [
+      {
+        "type": "RoundedRect",
+        "sprite": "assets/content/ui/ui.background.tile.psd",
+        "color": "1.0 1.0 1.0 1.0",
+        "radius": 24,
+        "segments": 12,
+        "preserveAspect": false
+      },
+      {
+        "type": "RectTransform",
+        "anchormin": "0.40 0.28",
+        "anchormax": "0.60 0.40",
+        "offsetmin": "0 0",
+        "offsetmax": "0 0"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

Adds a new `RoundedRect` Community UI component.

This component allows CUI authors to create rounded panels and images with configurable corner radius, edge softness, optional sprites, and aspect ratio preservation.

It is useful for building modern UI elements such as panels, cards, buttons, popups, image previews, and textured blocks.

## Example

```json
{
  "type": "RoundedRect",
  "color": "0.1 0.1 0.1 0.9",
  "radius": 24,
  "segments": 12,
  "softness": 1.5
}
```

## Textured example

```json
{
  "type": "RoundedRect",
  "sprite": "assets/content/ui/ui.background.tile.psd",
  "color": "1.0 1.0 1.0 1.0",
  "radius": 24,
  "segments": 12,
  "softness": 1.5,
  "preserveAspect": false
}
```

## Notes

- `radius` controls the corner rounding.
- `softness` adds a smoother transparent outer edge.
- `segments` controls how smooth the corner geometry is.
- `sprite` can be used to render rounded images or textured panels.
- `preserveAspect` keeps the sprite aspect ratio when needed.
- `radius` is clamped between `0` and `64`.
- `segments` is clamped between `1` and `64`.
- At render time, `radius` is also clamped to half of the rect width/height to avoid invalid geometry.

## Testing

Tested the component in a standalone Unity UI scene.

Added `Tests/RoundedRect.json` with examples for:
- rounded panels with different radius values
- edge softness
- textured rounded UI

<img width="1648" height="927" alt="image" src="https://github.com/user-attachments/assets/33213332-fadc-4f9f-92f1-6c2b2ae32c90" />
