### PR TITLE
Add HoverPreview 

### DIFF
--- a/CommunityEntity.UI.HoverPreview.cs
+++ b/CommunityEntity.UI.HoverPreview.cs
@@ -303,11 +303,7 @@ public partial class CommunityEntity
         {
             Initialize();
 
-            if ( transitionCoroutine != null )
-            {
-                StopCoroutine( transitionCoroutine );
-                transitionCoroutine = null;
-            }
+            StopTransition();
 
             if ( !container.gameObject.activeSelf )
                 return;

--- a/CommunityEntity.UI.HoverPreview.cs
+++ b/CommunityEntity.UI.HoverPreview.cs
@@ -248,11 +248,7 @@ public partial class CommunityEntity
         {
             Initialize();
 
-            if ( transitionCoroutine != null )
-            {
-                StopCoroutine( transitionCoroutine );
-                transitionCoroutine = null;
-            }
+            StopTransition();
 
             transitionCoroutine = StartCoroutine( ShowRoutine( title, description, image, style ) );
         }

--- a/CommunityEntity.UI.HoverPreview.cs
+++ b/CommunityEntity.UI.HoverPreview.cs
@@ -1,0 +1,772 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+public partial class CommunityEntity
+{
+#if CLIENT
+    public enum HoverPreviewContentAlignment
+    {
+        TopLeft,
+        TopCenter,
+        TopRight,
+        MiddleLeft,
+        MiddleCenter,
+        MiddleRight,
+        BottomLeft,
+        BottomCenter,
+        BottomRight
+    }
+
+    public struct HoverPreviewStyle
+    {
+        public Font TitleFont;
+        public Font DescriptionFont;
+
+        public int TitleFontSize;
+        public int DescriptionFontSize;
+
+        public Color TitleColor;
+        public Color DescriptionColor;
+        public Color ImageColor;
+        public Color BackgroundColor;
+
+        public float Spacing;
+        public float ImageHeight;
+        public HoverPreviewContentAlignment ContentAlignment;
+
+        public bool UseFade;
+        public float FadeInDuration;
+        public float FadeOutDuration;
+        public bool WaitFadeOutBeforeReplace;
+    }
+
+    public class HoverPreviewComponent : UIBehaviour, IPointerEnterHandler, IPointerExitHandler
+    {
+        public RectTransform previewRoot;
+
+        public string title = string.Empty;
+        public string description = string.Empty;
+        public Sprite image;
+
+        public bool hidePreviewOnExit = false;
+        public bool useFade = true;
+        public float fadeInDuration = 0.12f;
+        public float fadeOutDuration = 0.08f;
+        public bool waitFadeOutBeforeReplace = false;
+
+        public Font titleFont;
+        public Font descriptionFont;
+        public int titleFontSize = 22;
+        public int descriptionFontSize = 16;
+        public Color titleColor = Color.white;
+        public Color descriptionColor = new Color( 1f, 1f, 1f, 0.75f );
+        public Color imageColor = Color.white;
+        public Color backgroundColor = new Color( 0f, 0f, 0f, 0f );
+
+        public float spacing = 10f;
+        public float imageHeight = 220f;
+        public HoverPreviewContentAlignment contentAlignment = HoverPreviewContentAlignment.TopLeft;
+
+        public bool highlightOnHover = false;
+        public Color hoverColor = new Color( 1f, 1f, 1f, 0.12f );
+
+        private Graphic targetGraphic;
+        private Color originalColor;
+        private bool hasOriginalColor;
+
+        private HoverPreviewRoot previewController;
+        private bool isHovered;
+        private bool initialized;
+
+        public void Init()
+        {
+            if ( initialized )
+                return;
+
+            initialized = true;
+
+            targetGraphic = GetComponent<Graphic>();
+
+            if ( targetGraphic != null )
+            {
+                originalColor = targetGraphic.color;
+                hasOriginalColor = true;
+                targetGraphic.raycastTarget = true;
+            }
+
+            if ( titleFont == null )
+                titleFont = CommunityEntity.ClientInstance.LoadFont( "RobotoCondensed-Bold.ttf" );
+
+            if ( descriptionFont == null )
+                descriptionFont = CommunityEntity.ClientInstance.LoadFont( "RobotoCondensed-Regular.ttf" );
+        }
+
+        public void OnPointerEnter( PointerEventData eventData )
+        {
+            if ( !enabled )
+                return;
+
+            if ( isHovered )
+                return;
+
+            isHovered = true;
+
+            ApplyHoverColor();
+
+            HoverPreviewRoot controller = TryGetPreviewController();
+
+            if ( controller == null )
+                return;
+
+            HoverPreviewStyle style = new HoverPreviewStyle
+            {
+                TitleFont = titleFont,
+                DescriptionFont = descriptionFont,
+                TitleFontSize = titleFontSize,
+                DescriptionFontSize = descriptionFontSize,
+                TitleColor = titleColor,
+                DescriptionColor = descriptionColor,
+                ImageColor = imageColor,
+                BackgroundColor = backgroundColor,
+                Spacing = spacing,
+                ImageHeight = imageHeight,
+                ContentAlignment = contentAlignment,
+                UseFade = useFade,
+                FadeInDuration = fadeInDuration,
+                FadeOutDuration = fadeOutDuration,
+                WaitFadeOutBeforeReplace = waitFadeOutBeforeReplace
+            };
+
+            controller.Show( title, description, image, style );
+        }
+
+        public void OnPointerExit( PointerEventData eventData )
+        {
+            if ( !isHovered )
+                return;
+
+            isHovered = false;
+
+            RestoreColor();
+
+            if ( !hidePreviewOnExit )
+                return;
+
+            HoverPreviewRoot controller = TryGetPreviewController();
+
+            if ( controller != null )
+                controller.Hide( useFade, fadeOutDuration );
+        }
+
+        protected override void OnDisable()
+        {
+            base.OnDisable();
+
+            isHovered = false;
+            RestoreColor();
+
+            if ( hidePreviewOnExit && previewController != null )
+                previewController.HideInstant();
+        }
+
+        private HoverPreviewRoot TryGetPreviewController()
+        {
+            if ( previewRoot == null )
+                return null;
+
+            if ( previewController != null )
+                return previewController;
+
+            previewController = previewRoot.GetComponent<HoverPreviewRoot>();
+
+            if ( previewController == null )
+                previewController = previewRoot.gameObject.AddComponent<HoverPreviewRoot>();
+
+            previewController.Initialize();
+
+            return previewController;
+        }
+
+        private void ApplyHoverColor()
+        {
+            if ( !highlightOnHover || targetGraphic == null )
+                return;
+
+            if ( !hasOriginalColor )
+            {
+                originalColor = targetGraphic.color;
+                hasOriginalColor = true;
+            }
+
+            targetGraphic.color = hoverColor;
+        }
+
+        private void RestoreColor()
+        {
+            if ( !highlightOnHover || targetGraphic == null || !hasOriginalColor )
+                return;
+
+            targetGraphic.color = originalColor;
+        }
+    }
+
+    public class HoverPreviewRoot : MonoBehaviour
+    {
+        private RectTransform rootRect;
+
+        private RectTransform container;
+        private CanvasGroup containerCanvasGroup;
+        private Image containerBackground;
+
+        private RectTransform contentRoot;
+
+        private Coroutine transitionCoroutine;
+        private Coroutine fadeCoroutine;
+        private bool initialized;
+        private bool hasContent;
+
+        public void Initialize()
+        {
+            if ( initialized )
+                return;
+
+            initialized = true;
+
+            rootRect = GetComponent<RectTransform>();
+
+            if ( rootRect == null )
+                rootRect = gameObject.AddComponent<RectTransform>();
+
+            CreateContainer();
+            CreateContentRoot();
+            DisablePreviewRaycasts();
+        }
+
+        public void Show( string title, string description, Sprite image, HoverPreviewStyle style )
+        {
+            Initialize();
+
+            if ( transitionCoroutine != null )
+            {
+                StopCoroutine( transitionCoroutine );
+                transitionCoroutine = null;
+            }
+
+            transitionCoroutine = StartCoroutine( ShowRoutine( title, description, image, style ) );
+        }
+
+        private IEnumerator ShowRoutine( string title, string description, Sprite image, HoverPreviewStyle style )
+        {
+            if ( !gameObject.activeSelf )
+                gameObject.SetActive( true );
+
+            if ( !container.gameObject.activeSelf )
+                container.gameObject.SetActive( true );
+
+            bool hadContentBeforeBuild = hasContent;
+
+            bool shouldWaitOldFadeOut =
+                style.WaitFadeOutBeforeReplace &&
+                style.UseFade &&
+                hasContent &&
+                containerCanvasGroup.alpha > 0.01f &&
+                style.FadeOutDuration > 0f;
+
+            if ( shouldWaitOldFadeOut )
+                yield return FadeTo( 0f, style.FadeOutDuration );
+
+            ApplyRootStyle( style );
+            ClearContent();
+            BuildContent( title, description, image, style );
+            DisablePreviewRaycasts();
+
+            LayoutRebuilder.ForceRebuildLayoutImmediate( contentRoot );
+            LayoutRebuilder.ForceRebuildLayoutImmediate( container );
+            LayoutRebuilder.ForceRebuildLayoutImmediate( rootRect );
+
+            hasContent = true;
+
+            if ( !style.UseFade || style.FadeInDuration <= 0f )
+            {
+                containerCanvasGroup.alpha = 1f;
+                transitionCoroutine = null;
+                yield break;
+            }
+
+            if ( !hadContentBeforeBuild || shouldWaitOldFadeOut || containerCanvasGroup.alpha <= 0.01f )
+                containerCanvasGroup.alpha = 0f;
+
+            yield return FadeTo( 1f, style.FadeInDuration );
+
+            transitionCoroutine = null;
+        }
+
+        public void Hide( bool useFade, float duration )
+        {
+            Initialize();
+
+            if ( transitionCoroutine != null )
+            {
+                StopCoroutine( transitionCoroutine );
+                transitionCoroutine = null;
+            }
+
+            if ( !container.gameObject.activeSelf )
+                return;
+
+            if ( !useFade || duration <= 0f )
+            {
+                HideInstant();
+                return;
+            }
+
+            transitionCoroutine = StartCoroutine( HideRoutine( duration ) );
+        }
+
+        private IEnumerator HideRoutine( float duration )
+        {
+            yield return FadeTo( 0f, duration );
+
+            container.gameObject.SetActive( false );
+            hasContent = false;
+            transitionCoroutine = null;
+        }
+
+        public void HideInstant()
+        {
+            Initialize();
+
+            StopTransition();
+
+            containerCanvasGroup.alpha = 0f;
+            container.gameObject.SetActive( false );
+            hasContent = false;
+        }
+
+        public void ClearContent()
+        {
+            Initialize();
+
+            if ( contentRoot == null )
+                return;
+
+            for ( int i = contentRoot.childCount - 1; i >= 0; i-- )
+            {
+                Transform child = contentRoot.GetChild( i );
+
+                if ( Application.isPlaying )
+                    Destroy( child.gameObject );
+                else
+                    DestroyImmediate( child.gameObject );
+            }
+
+            hasContent = false;
+        }
+
+        private void CreateContainer()
+        {
+            Transform existing = transform.Find( "__HoverPreviewContainer" );
+
+            if ( existing != null )
+                container = existing as RectTransform;
+
+            if ( container == null )
+            {
+                GameObject containerObject = new GameObject(
+                    "__HoverPreviewContainer",
+                    typeof( RectTransform ),
+                    typeof( CanvasGroup ),
+                    typeof( Image )
+                );
+
+                containerObject.transform.SetParent( transform, false );
+                container = containerObject.GetComponent<RectTransform>();
+            }
+
+            container.anchorMin = Vector2.zero;
+            container.anchorMax = Vector2.one;
+            container.pivot = new Vector2( 0.5f, 0.5f );
+            container.offsetMin = Vector2.zero;
+            container.offsetMax = Vector2.zero;
+
+            containerCanvasGroup = container.GetComponent<CanvasGroup>();
+
+            if ( containerCanvasGroup == null )
+                containerCanvasGroup = container.gameObject.AddComponent<CanvasGroup>();
+
+            containerCanvasGroup.interactable = false;
+            containerCanvasGroup.blocksRaycasts = false;
+            containerCanvasGroup.alpha = 0f;
+
+            containerBackground = container.GetComponent<Image>();
+
+            if ( containerBackground == null )
+                containerBackground = container.gameObject.AddComponent<Image>();
+
+            containerBackground.raycastTarget = false;
+        }
+
+        private void CreateContentRoot()
+        {
+            Transform existing = container.Find( "__HoverPreviewContent" );
+
+            if ( existing != null )
+                contentRoot = existing as RectTransform;
+
+            if ( contentRoot == null )
+            {
+                GameObject contentObject = new GameObject(
+                    "__HoverPreviewContent",
+                    typeof( RectTransform ),
+                    typeof( VerticalLayoutGroup )
+                );
+
+                contentObject.transform.SetParent( container, false );
+                contentRoot = contentObject.GetComponent<RectTransform>();
+            }
+
+            contentRoot.anchorMin = Vector2.zero;
+            contentRoot.anchorMax = Vector2.one;
+            contentRoot.pivot = new Vector2( 0.5f, 0.5f );
+            contentRoot.offsetMin = Vector2.zero;
+            contentRoot.offsetMax = Vector2.zero;
+
+            VerticalLayoutGroup layout = contentRoot.GetComponent<VerticalLayoutGroup>();
+
+            if ( layout == null )
+                layout = contentRoot.gameObject.AddComponent<VerticalLayoutGroup>();
+
+            layout.padding = new RectOffset( 0, 0, 0, 0 );
+            layout.childAlignment = TextAnchor.UpperLeft;
+            layout.childControlWidth = true;
+            layout.childControlHeight = true;
+            layout.childForceExpandWidth = false;
+            layout.childForceExpandHeight = false;
+        }
+
+        private void ApplyRootStyle( HoverPreviewStyle style )
+        {
+            if ( style.BackgroundColor.a > 0f )
+            {
+                containerBackground.color = style.BackgroundColor;
+                containerBackground.enabled = true;
+                containerBackground.raycastTarget = false;
+            }
+            else
+            {
+                containerBackground.enabled = false;
+                containerBackground.raycastTarget = false;
+            }
+
+            VerticalLayoutGroup layout = contentRoot.GetComponent<VerticalLayoutGroup>();
+            layout.padding = new RectOffset( 0, 0, 0, 0 );
+            layout.spacing = style.Spacing;
+            layout.childAlignment = ToLayoutAlignment( style.ContentAlignment );
+            layout.childControlWidth = true;
+            layout.childControlHeight = true;
+            layout.childForceExpandWidth = false;
+            layout.childForceExpandHeight = false;
+        }
+
+        private void BuildContent( string title, string description, Sprite image, HoverPreviewStyle style )
+        {
+            bool hasTitle = !string.IsNullOrEmpty( title );
+            bool hasDescription = !string.IsNullOrEmpty( description );
+            bool hasImage = image != null;
+
+            TextAnchor textAlignment = ToTextAlignment( style.ContentAlignment );
+
+            if ( hasTitle )
+            {
+                CreateText(
+                    "Title",
+                    title,
+                    style.TitleFont,
+                    style.TitleFontSize,
+                    FontStyle.Bold,
+                    style.TitleColor,
+                    textAlignment
+                );
+            }
+
+            if ( hasDescription )
+            {
+                CreateText(
+                    "Description",
+                    description,
+                    style.DescriptionFont,
+                    style.DescriptionFontSize,
+                    FontStyle.Normal,
+                    style.DescriptionColor,
+                    textAlignment
+                );
+            }
+
+            if ( hasImage )
+            {
+                CreateImage(
+                    "Image",
+                    image,
+                    style.ImageColor,
+                    style.ImageHeight
+                );
+            }
+        }
+
+        private Text CreateText(
+            string objectName,
+            string value,
+            Font font,
+            int fontSize,
+            FontStyle fontStyle,
+            Color color,
+            TextAnchor alignment
+        )
+        {
+            GameObject go = new GameObject(
+                objectName,
+                typeof( RectTransform ),
+                typeof( CanvasRenderer ),
+                typeof( Text ),
+                typeof( ContentSizeFitter ),
+                typeof( LayoutElement )
+            );
+
+            go.transform.SetParent( contentRoot, false );
+
+            float width = GetAvailableContentWidth();
+
+            RectTransform rect = go.GetComponent<RectTransform>();
+            rect.anchorMin = new Vector2( 0f, 1f );
+            rect.anchorMax = new Vector2( 0f, 1f );
+            rect.pivot = GetChildPivot( alignment );
+            rect.sizeDelta = new Vector2( width, 0f );
+
+            Text text = go.GetComponent<Text>();
+            text.text = value;
+            text.font = font;
+            text.fontSize = fontSize;
+            text.fontStyle = fontStyle;
+            text.color = color;
+            text.alignment = alignment;
+            text.horizontalOverflow = HorizontalWrapMode.Wrap;
+            text.verticalOverflow = VerticalWrapMode.Overflow;
+            text.raycastTarget = false;
+
+            ContentSizeFitter fitter = go.GetComponent<ContentSizeFitter>();
+            fitter.horizontalFit = ContentSizeFitter.FitMode.Unconstrained;
+            fitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+
+            LayoutElement layoutElement = go.GetComponent<LayoutElement>();
+            layoutElement.minHeight = fontSize + 4f;
+            layoutElement.preferredWidth = width;
+            layoutElement.flexibleWidth = 0f;
+            layoutElement.flexibleHeight = 0f;
+
+            return text;
+        }
+
+        private Image CreateImage(
+            string objectName,
+            Sprite sprite,
+            Color color,
+            float height
+        )
+        {
+            GameObject go = new GameObject(
+                objectName,
+                typeof( RectTransform ),
+                typeof( CanvasRenderer ),
+                typeof( Image ),
+                typeof( LayoutElement )
+            );
+
+            go.transform.SetParent( contentRoot, false );
+
+            float width = height;
+
+            if ( sprite != null && sprite.rect.height > 0f )
+                width = height * ( sprite.rect.width / sprite.rect.height );
+
+            width = Mathf.Min( width, GetAvailableContentWidth() );
+
+            RectTransform rect = go.GetComponent<RectTransform>();
+            rect.anchorMin = new Vector2( 0f, 1f );
+            rect.anchorMax = new Vector2( 0f, 1f );
+            rect.pivot = new Vector2( 0.5f, 1f );
+            rect.sizeDelta = new Vector2( width, height );
+
+            Image img = go.GetComponent<Image>();
+            img.sprite = sprite;
+            img.color = color;
+            img.preserveAspect = true;
+            img.raycastTarget = false;
+
+            LayoutElement layoutElement = go.GetComponent<LayoutElement>();
+            layoutElement.minWidth = width;
+            layoutElement.preferredWidth = width;
+            layoutElement.minHeight = height;
+            layoutElement.preferredHeight = height;
+            layoutElement.flexibleWidth = 0f;
+            layoutElement.flexibleHeight = 0f;
+
+            return img;
+        }
+
+        private float GetAvailableContentWidth()
+        {
+            if ( rootRect == null )
+                return 0f;
+
+            return Mathf.Max( 0f, rootRect.rect.width );
+        }
+
+        private IEnumerator FadeTo( float targetAlpha, float duration )
+        {
+            if ( fadeCoroutine != null )
+            {
+                StopCoroutine( fadeCoroutine );
+                fadeCoroutine = null;
+            }
+
+            fadeCoroutine = StartCoroutine( Fade( targetAlpha, duration ) );
+
+            yield return fadeCoroutine;
+
+            fadeCoroutine = null;
+        }
+
+        private IEnumerator Fade( float targetAlpha, float duration )
+        {
+            float startAlpha = containerCanvasGroup.alpha;
+            float time = 0f;
+            float safeDuration = Mathf.Max( 0.01f, duration );
+
+            while ( time < safeDuration )
+            {
+                time += Time.unscaledDeltaTime;
+
+                float t = Mathf.Clamp01( time / safeDuration );
+                t = t * t * ( 3f - 2f * t );
+
+                containerCanvasGroup.alpha = Mathf.Lerp( startAlpha, targetAlpha, t );
+
+                yield return null;
+            }
+
+            containerCanvasGroup.alpha = targetAlpha;
+        }
+
+        private void StopTransition()
+        {
+            if ( transitionCoroutine != null )
+            {
+                StopCoroutine( transitionCoroutine );
+                transitionCoroutine = null;
+            }
+
+            if ( fadeCoroutine != null )
+            {
+                StopCoroutine( fadeCoroutine );
+                fadeCoroutine = null;
+            }
+        }
+
+        private void DisablePreviewRaycasts()
+        {
+            if ( containerCanvasGroup != null )
+            {
+                containerCanvasGroup.interactable = false;
+                containerCanvasGroup.blocksRaycasts = false;
+            }
+
+            if ( containerBackground != null )
+                containerBackground.raycastTarget = false;
+
+            if ( contentRoot == null )
+                return;
+
+            Graphic[] graphics = contentRoot.GetComponentsInChildren<Graphic>( true );
+
+            for ( int i = 0; i < graphics.Length; i++ )
+                graphics[i].raycastTarget = false;
+        }
+
+        private static TextAnchor ToLayoutAlignment( HoverPreviewContentAlignment alignment )
+        {
+            switch ( alignment )
+            {
+                case HoverPreviewContentAlignment.TopLeft:
+                    return TextAnchor.UpperLeft;
+
+                case HoverPreviewContentAlignment.TopCenter:
+                    return TextAnchor.UpperCenter;
+
+                case HoverPreviewContentAlignment.TopRight:
+                    return TextAnchor.UpperRight;
+
+                case HoverPreviewContentAlignment.MiddleLeft:
+                    return TextAnchor.MiddleLeft;
+
+                case HoverPreviewContentAlignment.MiddleCenter:
+                    return TextAnchor.MiddleCenter;
+
+                case HoverPreviewContentAlignment.MiddleRight:
+                    return TextAnchor.MiddleRight;
+
+                case HoverPreviewContentAlignment.BottomLeft:
+                    return TextAnchor.LowerLeft;
+
+                case HoverPreviewContentAlignment.BottomCenter:
+                    return TextAnchor.LowerCenter;
+
+                case HoverPreviewContentAlignment.BottomRight:
+                    return TextAnchor.LowerRight;
+
+                default:
+                    return TextAnchor.UpperLeft;
+            }
+        }
+
+        private static TextAnchor ToTextAlignment( HoverPreviewContentAlignment alignment )
+        {
+            switch ( alignment )
+            {
+                case HoverPreviewContentAlignment.TopCenter:
+                case HoverPreviewContentAlignment.MiddleCenter:
+                case HoverPreviewContentAlignment.BottomCenter:
+                    return TextAnchor.UpperCenter;
+
+                case HoverPreviewContentAlignment.TopRight:
+                case HoverPreviewContentAlignment.MiddleRight:
+                case HoverPreviewContentAlignment.BottomRight:
+                    return TextAnchor.UpperRight;
+
+                default:
+                    return TextAnchor.UpperLeft;
+            }
+        }
+
+        private static Vector2 GetChildPivot( TextAnchor alignment )
+        {
+            switch ( alignment )
+            {
+                case TextAnchor.UpperCenter:
+                case TextAnchor.MiddleCenter:
+                case TextAnchor.LowerCenter:
+                    return new Vector2( 0.5f, 1f );
+
+                case TextAnchor.UpperRight:
+                case TextAnchor.MiddleRight:
+                case TextAnchor.LowerRight:
+                    return new Vector2( 1f, 1f );
+
+                default:
+                    return new Vector2( 0f, 1f );
+            }
+        }
+    }
+#endif
+}

--- a/CommunityEntity.UI.cs
+++ b/CommunityEntity.UI.cs
@@ -850,6 +850,93 @@ public partial class CommunityEntity
                         scrollRect.verticalNormalizedPosition = obj.GetFloat("verticalNormalizedPosition", 1f);
                 break;
                 }
+
+            case "HoverPreview":
+                {
+                    var c = GetOrAddComponent<HoverPreviewComponent>();
+
+                    if ( ShouldUpdateField( "target" ) )
+                    {
+                        string targetName = obj.GetString( "target", string.Empty );
+                        GameObject target = !string.IsNullOrEmpty( targetName ) ? FindPanel( targetName ) : null;
+
+                        c.previewRoot = target != null ? target.GetComponent<RectTransform>() : null;
+                    }
+
+                    if ( ShouldUpdateField( "title" ) )
+                        c.title = obj.GetString( "title", string.Empty );
+
+                    if ( ShouldUpdateField( "description" ) )
+                        c.description = obj.GetString( "description", string.Empty );
+
+                    if ( ShouldUpdateField( "sprite" ) )
+                    {
+                        string spritePath = obj.GetString( "sprite", string.Empty );
+                        c.image = !string.IsNullOrEmpty( spritePath ) ? FileSystem.Load<Sprite>( spritePath ) : null;
+                    }
+
+                    if ( ShouldUpdateField( "hidePreviewOnExit" ) )
+                        c.hidePreviewOnExit = obj.GetBoolean( "hidePreviewOnExit", false );
+
+                    if ( ShouldUpdateField( "useFade" ) )
+                        c.useFade = obj.GetBoolean( "useFade", true );
+
+                    if ( ShouldUpdateField( "fadeIn" ) )
+                        c.fadeInDuration = obj.GetFloat( "fadeIn", 0.12f );
+
+                    if ( ShouldUpdateField( "fadeOut" ) )
+                        c.fadeOutDuration = obj.GetFloat( "fadeOut", 0.08f );
+
+                    if ( ShouldUpdateField( "waitFadeOutBeforeReplace" ) )
+                        c.waitFadeOutBeforeReplace = obj.GetBoolean( "waitFadeOutBeforeReplace", false );
+
+                    if ( ShouldUpdateField( "titleFont" ) )
+                        c.titleFont = LoadFont( obj.GetString( "titleFont", "RobotoCondensed-Bold.ttf" ) );
+
+                    if ( ShouldUpdateField( "descriptionFont" ) )
+                        c.descriptionFont = LoadFont( obj.GetString( "descriptionFont", "RobotoCondensed-Regular.ttf" ) );
+
+                    if ( ShouldUpdateField( "titleFontSize" ) )
+                        c.titleFontSize = obj.GetInt( "titleFontSize", 22 );
+
+                    if ( ShouldUpdateField( "descriptionFontSize" ) )
+                        c.descriptionFontSize = obj.GetInt( "descriptionFontSize", 16 );
+
+                    if ( ShouldUpdateField( "titleColor" ) )
+                        c.titleColor = ColorEx.Parse( obj.GetString( "titleColor", "1 1 1 1" ) );
+
+                    if ( ShouldUpdateField( "descriptionColor" ) )
+                        c.descriptionColor = ColorEx.Parse( obj.GetString( "descriptionColor", "1 1 1 0.75" ) );
+
+                    if ( ShouldUpdateField( "imageColor" ) )
+                        c.imageColor = ColorEx.Parse( obj.GetString( "imageColor", "1 1 1 1" ) );
+
+                    if ( ShouldUpdateField( "backgroundColor" ) )
+                        c.backgroundColor = ColorEx.Parse( obj.GetString( "backgroundColor", "0 0 0 0" ) );
+
+                    if ( ShouldUpdateField( "spacing" ) )
+                        c.spacing = obj.GetFloat( "spacing", 10f );
+
+                    if ( ShouldUpdateField( "imageHeight" ) )
+                        c.imageHeight = obj.GetFloat( "imageHeight", 220f );
+
+                    if ( ShouldUpdateField( "contentAlignment" ) )
+                        c.contentAlignment = ParseEnum(
+                            obj.GetString( "contentAlignment", "TopLeft" ),
+                            HoverPreviewContentAlignment.TopLeft
+                        );
+
+                    if ( ShouldUpdateField( "highlightOnHover" ) )
+                        c.highlightOnHover = obj.GetBoolean( "highlightOnHover", false );
+
+                    if ( ShouldUpdateField( "hoverColor" ) )
+                        c.hoverColor = ColorEx.Parse( obj.GetString( "hoverColor", "1 1 1 0.12" ) );
+
+                    c.Init();
+
+                    HandleEnableState( obj, c );
+                    break;
+                }
         }
     }
 

--- a/Tests/HoverPreviewTest.json
+++ b/Tests/HoverPreviewTest.json
@@ -1,0 +1,288 @@
+[
+  {
+    "name": "UI",
+    "parent": "Overlay",
+    "components": [
+      {
+        "type": "UnityEngine.UI.RawImage",
+        "color": "0 0 0 0.45"
+      },
+      {
+        "type": "RectTransform",
+        "anchormin": "0 0",
+        "anchormax": "1 1",
+        "offsetmin": "0 0",
+        "offsetmax": "0 0"
+      },
+      {
+        "type": "NeedsCursor"
+      }
+    ]
+  },
+
+  {
+    "name": "PreviewRoot",
+    "parent": "UI",
+    "components": [
+      {
+        "type": "RectTransform",
+        "anchormin": "0.5 1",
+        "anchormax": "0.5 1",
+        "offsetmin": "310 -350",
+        "offsetmax": "560 -90"
+      }
+    ]
+  },
+
+  {
+    "name": "Row1",
+    "parent": "UI",
+    "components": [
+      {
+        "type": "UnityEngine.UI.RawImage",
+        "color": "0 0 0 0.75"
+      },
+      {
+        "type": "RectTransform",
+        "anchormin": "0.5 1",
+        "anchormax": "0.5 1",
+        "offsetmin": "-470 -155",
+        "offsetmax": "300 -95"
+      }
+    ]
+  },
+  {
+    "parent": "Row1",
+    "components": [
+      {
+        "type": "UnityEngine.UI.Text",
+        "text": "TEST PANEL",
+        "fontSize": 30,
+        "color": "1 1 1 0.9",
+        "align": "MiddleLeft"
+      },
+      {
+        "type": "RectTransform",
+        "offsetmin": "25 0",
+        "offsetmax": "-330 0"
+      }
+    ]
+  },
+  {
+    "name": "Button1",
+    "parent": "Row1",
+    "components": [
+      {
+        "type": "UnityEngine.UI.Button",
+        "color": "0.25 0.25 0.25 1",
+        "highlightedColor": "0.35 0.35 0.35 1",
+        "pressedColor": "0.2 0.2 0.2 1",
+        "fadeDuration": 0.08
+      },
+      {
+        "type": "RectTransform",
+        "anchormin": "1 0.5",
+        "anchormax": "1 0.5",
+        "offsetmin": "-295 -25",
+        "offsetmax": "-5 25"
+      },
+      {
+        "type": "HoverPreview",
+        "target": "PreviewRoot",
+        "title": "Title",
+        "description": "Description",
+        "titleFontSize": 28,
+        "descriptionFontSize": 18,
+        "titleColor": "1 1 1 1",
+        "descriptionColor": "1 1 1 0.75",
+        "imageColor": "0.75 0 0 1",
+        "spacing": 4,
+        "imageHeight": 190,
+        "contentAlignment": "TopLeft",
+        "fadeIn": 0.12,
+        "fadeOut": 0.08,
+        "waitFadeOutBeforeReplace": true
+      }
+    ]
+  },
+  {
+    "parent": "Button1",
+    "components": [
+      {
+        "type": "UnityEngine.UI.Text",
+        "text": "Test 1",
+        "fontSize": 30,
+        "color": "1 1 1 0.8",
+        "align": "MiddleCenter"
+      }
+    ]
+  },
+
+  {
+    "name": "Row2",
+    "parent": "UI",
+    "components": [
+      {
+        "type": "UnityEngine.UI.RawImage",
+        "color": "0.06 0.1 0.15 0.75"
+      },
+      {
+        "type": "RectTransform",
+        "anchormin": "0.5 1",
+        "anchormax": "0.5 1",
+        "offsetmin": "-470 -240",
+        "offsetmax": "300 -180"
+      }
+    ]
+  },
+  {
+    "parent": "Row2",
+    "components": [
+      {
+        "type": "UnityEngine.UI.Text",
+        "text": "TEST PANEL",
+        "fontSize": 30,
+        "color": "1 1 1 0.9",
+        "align": "MiddleLeft"
+      },
+      {
+        "type": "RectTransform",
+        "offsetmin": "25 0",
+        "offsetmax": "-330 0"
+      }
+    ]
+  },
+  {
+    "name": "Button2",
+    "parent": "Row2",
+    "components": [
+      {
+        "type": "UnityEngine.UI.Button",
+        "color": "0.25 0.25 0.25 1",
+        "highlightedColor": "0.35 0.35 0.35 1",
+        "pressedColor": "0.2 0.2 0.2 1",
+        "fadeDuration": 0.08
+      },
+      {
+        "type": "RectTransform",
+        "anchormin": "1 0.5",
+        "anchormax": "1 0.5",
+        "offsetmin": "-295 -25",
+        "offsetmax": "-5 25"
+      },
+      {
+        "type": "HoverPreview",
+        "target": "PreviewRoot",
+        "title": "Second Title",
+        "description": "Another preview block",
+        "titleFontSize": 28,
+        "descriptionFontSize": 18,
+        "titleColor": "1 1 1 1",
+        "descriptionColor": "1 1 1 0.75",
+        "imageColor": "0.1 0.45 1 1",
+        "spacing": 4,
+        "imageHeight": 190,
+        "contentAlignment": "TopLeft",
+        "fadeIn": 0.12,
+        "fadeOut": 0.08,
+        "waitFadeOutBeforeReplace": true
+      }
+    ]
+  },
+  {
+    "parent": "Button2",
+    "components": [
+      {
+        "type": "UnityEngine.UI.Text",
+        "text": "Test 2",
+        "fontSize": 30,
+        "color": "1 1 1 0.8",
+        "align": "MiddleCenter"
+      }
+    ]
+  },
+
+  {
+    "name": "Row3",
+    "parent": "UI",
+    "components": [
+      {
+        "type": "UnityEngine.UI.RawImage",
+        "color": "0.06 0.1 0.15 0.75"
+      },
+      {
+        "type": "RectTransform",
+        "anchormin": "0.5 1",
+        "anchormax": "0.5 1",
+        "offsetmin": "-470 -325",
+        "offsetmax": "300 -265"
+      }
+    ]
+  },
+  {
+    "parent": "Row3",
+    "components": [
+      {
+        "type": "UnityEngine.UI.Text",
+        "text": "TEST PANEL",
+        "fontSize": 30,
+        "color": "1 1 1 0.9",
+        "align": "MiddleLeft"
+      },
+      {
+        "type": "RectTransform",
+        "offsetmin": "25 0",
+        "offsetmax": "-330 0"
+      }
+    ]
+  },
+  {
+    "name": "Button3",
+    "parent": "Row3",
+    "components": [
+      {
+        "type": "UnityEngine.UI.Button",
+        "color": "0.25 0.25 0.25 1",
+        "highlightedColor": "0.35 0.35 0.35 1",
+        "pressedColor": "0.2 0.2 0.2 1",
+        "fadeDuration": 0.08
+      },
+      {
+        "type": "RectTransform",
+        "anchormin": "1 0.5",
+        "anchormax": "1 0.5",
+        "offsetmin": "-295 -25",
+        "offsetmax": "-5 25"
+      },
+      {
+        "type": "HoverPreview",
+        "target": "PreviewRoot",
+        "title": "Third Title",
+        "description": "Third preview example",
+        "titleFontSize": 28,
+        "descriptionFontSize": 18,
+        "titleColor": "1 1 1 1",
+        "descriptionColor": "1 1 1 0.75",
+        "imageColor": "1 0.8 0.1 1",
+        "spacing": 4,
+        "imageHeight": 190,
+        "contentAlignment": "TopLeft",
+        "fadeIn": 0.12,
+        "fadeOut": 0.08,
+        "waitFadeOutBeforeReplace": true
+      }
+    ]
+  },
+  {
+    "parent": "Button3",
+    "components": [
+      {
+        "type": "UnityEngine.UI.Text",
+        "text": "Test 3",
+        "fontSize": 30,
+        "color": "1 1 1 0.8",
+        "align": "MiddleCenter"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

Added the `HoverPreview` component for UI elements.

Buttons and other elements can now show a preview panel on hover. Preview content is configured through JSON and can include a title, description, image, colors, fonts, alignment, and fade animation.

## What changed

- Added `HoverPreviewComponent` for handling hover events.
- Added `HoverPreviewRoot` for displaying preview content.
- Added JSON support for:
  - title
  - description
  - image
  - colors
  - font sizes
  - spacing
  - alignment
  - fade in / fade out
  - hiding the preview on pointer exit
- Preview does not block clicks or hover events.
- Added a test JSON with multiple buttons.

https://github.com/user-attachments/assets/422ba03c-8a26-4a44-8b01-c053b2f95279

