### PR TITLE
Added DestroyOnly requests in AddUI JSON.

### DIFF
--- a/CommunityEntity.UI.cs
+++ b/CommunityEntity.UI.cs
@@ -88,6 +88,11 @@ public partial class CommunityEntity
             if ( json.ContainsKey( "destroyUi" ) )
             {
                 DestroyPanel( json.GetString( "destroyUi", "AddUI CreatedPanel" ) );
+                if(json.GetBoolean("destroyOnly", false))
+                {
+                    //This request is only to destroy the panel. Continue to the next element.
+                    continue;
+                }
             }
             var parentPanel = FindPanel( json.GetString( "parent", "Overlay" ) );
             var gameObjectName = json.GetString( "name", "AddUI CreatedPanel" );


### PR DESCRIPTION
Added the ability to specify in the AddUI JSON if we should only destroy the UI element and skip further processing. 
This will allow developers the following options when sending AddUi JSON:

1. Specify multiple destroy UI requests without having to send multiple RPC's
2. Ability to include Destroy UI requests while also creating/updating UI.

Example Destroy only JSON:
```json
[
    {
        "destroyUi": "Ui1",
        "destroyOnly": true
    },
    {
        "destroyUi": "Ui2",
        "destroyOnly": true
    }
]
```